### PR TITLE
Fix ASSET_URL not reaching PHP-FPM behind reverse proxy (#2026)

### DIFF
--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -65,6 +65,13 @@ if [ "${BEHIND_PROXY}" == "true" ]; then
   export PARSED_APP_URL=":80"
   export PARSED_AUTO_HTTPS="auto_https off"
   export ASSET_URL=${APP_URL}
+
+  # Write ASSET_URL to .env so PHP-FPM workers can read it (clear_env = yes by default)
+  if grep -q "^ASSET_URL=" /pelican-data/.env; then
+    sed -i "s|^ASSET_URL=.*|ASSET_URL=${APP_URL}|" /pelican-data/.env
+  else
+    echo "ASSET_URL=${APP_URL}" >> /pelican-data/.env
+  fi
 fi
 
 # disable caddy if SKIP_CADDY is set

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -67,10 +67,17 @@ if [ "${BEHIND_PROXY}" == "true" ]; then
   export ASSET_URL=${APP_URL}
 
   # Write ASSET_URL to .env so PHP-FPM workers can read it (clear_env = yes by default)
-  if grep -q "^ASSET_URL=" /pelican-data/.env; then
-    sed -i "s|^ASSET_URL=.*|ASSET_URL=${APP_URL}|" /pelican-data/.env
+  ENV_FILE="/var/www/html/.env"
+  if [ -e "$ENV_FILE" ]; then
+    ENV_FILE="$(readlink -f "$ENV_FILE")"
   else
-    echo "ASSET_URL=${APP_URL}" >> /pelican-data/.env
+    ENV_FILE="/pelican-data/.env"
+  fi
+  ESCAPED_APP_URL="$(printf '%s' "$APP_URL" | sed 's/[&|]/\\&/g')"
+  if grep -q "^ASSET_URL=" "$ENV_FILE"; then
+    sed -i "s|^ASSET_URL=.*|ASSET_URL=${ESCAPED_APP_URL}|" "$ENV_FILE"
+  else
+    echo "ASSET_URL=${APP_URL}" >> "$ENV_FILE"
   fi
 fi
 


### PR DESCRIPTION
PHP-FPM's clear_env default strips shell environment variables, so the exported ASSET_URL was never visible to Laravel. This persists it to .env where Dotenv can read it.

Fixes #2026