### PR TITLE
Add option to delete S3 backups from storage on server deletion

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -30,6 +30,7 @@ use App\Traits\Filament\CanCustomizeTabs;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
+use Filament\Forms\Components\Checkbox;
 use Filament\Forms\Components\CheckboxList;
 use Filament\Forms\Components\FileUpload;
 use Filament\Forms\Components\Hidden;
@@ -1106,9 +1107,13 @@ class EditServer extends EditRecord
                 ->modalHeading(trans('filament-actions::delete.single.modal.heading', ['label' => $this->getRecordTitle()]))
                 ->modalSubmitActionLabel(trans('filament-actions::delete.single.label'))
                 ->requiresConfirmation()
-                ->action(function (Server $server, ServerDeletionService $service) {
+                ->form(fn (Server $server) => $server->backups()->where('is_locked', false)->exists() ? [
+                    Checkbox::make('delete_backups')
+                        ->label(trans('admin/server.delete_backups', ['count' => $server->backups()->where('is_locked', false)->count()])),
+                ] : [])
+                ->action(function (array $data, Server $server, ServerDeletionService $service) {
                     try {
-                        $service->handle($server);
+                        $service->withDeleteBackups($data['delete_backups'] ?? false)->handle($server);
 
                         return redirect(ListServers::getUrl(panel: 'admin'));
                     } catch (ConnectionException) {
@@ -1132,9 +1137,13 @@ class EditServer extends EditRecord
                 ->modalHeading(trans('filament-actions::force-delete.single.modal.heading', ['label' => $this->getRecordTitle()]))
                 ->modalSubmitActionLabel(trans('filament-actions::force-delete.single.label'))
                 ->requiresConfirmation()
-                ->action(function (Server $server, ServerDeletionService $service) {
+                ->form(fn (Server $server) => $server->backups()->where('is_locked', false)->exists() ? [
+                    Checkbox::make('delete_backups')
+                        ->label(trans('admin/server.delete_backups', ['count' => $server->backups()->where('is_locked', false)->count()])),
+                ] : [])
+                ->action(function (array $data, Server $server, ServerDeletionService $service) {
                     try {
-                        $service->withForce()->handle($server);
+                        $service->withForce()->withDeleteBackups($data['delete_backups'] ?? false)->handle($server);
 
                         return redirect(ListServers::getUrl(panel: 'admin'));
                     } catch (ConnectionException) {

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -98,6 +98,7 @@ return [
     'delete_db' => 'Are you sure you want to delete :name ?',
     'delete_db_heading' => 'Delete Database?',
     'backups' => 'Backups',
+    'delete_backups' => 'Also delete :count backup(s) from storage',
     'egg' => 'Egg',
     'mounts' => 'Mounts',
     'no_mounts' => 'No Mounts exist for this Node',


### PR DESCRIPTION
When deleting a server, a checkbox now appears in the confirmation modal if unlocked backups exist, allowing admins to also remove them from storage via DeleteBackupService. Locked backups are always preserved.

Resolves #2163