### PR TITLE
Add admin activity logging for CRUD operations

### DIFF
--- a/app/Listeners/AdminActivityListener.php
+++ b/app/Listeners/AdminActivityListener.php
@@ -4,8 +4,8 @@ namespace App\Listeners;
 
 use App\Facades\Activity;
 use Filament\Facades\Filament;
-use Filament\Resources\Pages\Page;
-use Illuminate\Database\Eloquent\Model;
+use Filament\Resources\Events\RecordCreated;
+use Filament\Resources\Events\RecordUpdated;
 use Illuminate\Support\Str;
 
 class AdminActivityListener
@@ -13,23 +13,29 @@ class AdminActivityListener
     protected const REDACTED_FIELDS = [
         'password',
         'password_confirmation',
+        'current_password',
         'token',
         'secret',
         'api_key',
+        'daemon_token',
+        '_token',
     ];
 
-    /** @param array<string, mixed> $data */
-    public function handle(Model $record, array $data, Page $page): void
+    public function handle(RecordCreated|RecordUpdated $event): void
     {
         if (Filament::getCurrentPanel()?->getId() !== 'admin') {
             return;
         }
 
+        $record = $event->getRecord();
+        $page = $event->getPage();
+        $data = $event->getData();
+
         $resourceClass = $page::getResource();
         $modelClass = $resourceClass::getModel();
         $slug = Str::kebab(class_basename($modelClass));
 
-        $action = $page instanceof \Filament\Resources\Pages\CreateRecord ? 'create' : 'update';
+        $action = $event instanceof RecordCreated ? 'create' : 'update';
 
         $properties = $this->redactSensitiveFields($data);
 
@@ -49,6 +55,8 @@ class AdminActivityListener
 
         foreach ($data as $key => $value) {
             if (in_array($key, self::REDACTED_FIELDS, true)) {
+                $redacted[$key] = '[REDACTED]';
+
                 continue;
             }
 

--- a/app/Listeners/AdminActivityListener.php
+++ b/app/Listeners/AdminActivityListener.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Listeners;
+
+use App\Facades\Activity;
+use Filament\Facades\Filament;
+use Filament\Resources\Pages\Page;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Support\Str;
+
+class AdminActivityListener
+{
+    protected const REDACTED_FIELDS = [
+        'password',
+        'password_confirmation',
+        'token',
+        'secret',
+        'api_key',
+    ];
+
+    /** @param array<string, mixed> $data */
+    public function handle(Model $record, array $data, Page $page): void
+    {
+        if (Filament::getCurrentPanel()?->getId() !== 'admin') {
+            return;
+        }
+
+        $resourceClass = $page::getResource();
+        $modelClass = $resourceClass::getModel();
+        $slug = Str::kebab(class_basename($modelClass));
+
+        $action = $page instanceof \Filament\Resources\Pages\CreateRecord ? 'create' : 'update';
+
+        $properties = $this->redactSensitiveFields($data);
+
+        Activity::event("admin:$slug.$action")
+            ->subject($record)
+            ->property($properties)
+            ->log();
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @return array<string, mixed>
+     */
+    protected function redactSensitiveFields(array $data): array
+    {
+        $redacted = [];
+
+        foreach ($data as $key => $value) {
+            if (in_array($key, self::REDACTED_FIELDS, true)) {
+                continue;
+            }
+
+            if (is_array($value)) {
+                $redacted[$key] = $this->redactSensitiveFields($value);
+            } else {
+                $redacted[$key] = $value;
+            }
+        }
+
+        return $redacted;
+    }
+}

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -2,7 +2,10 @@
 
 namespace App\Providers;
 
+use App\Listeners\AdminActivityListener;
 use App\Listeners\DispatchWebhooks;
+use Filament\Resources\Events\RecordCreated;
+use Filament\Resources\Events\RecordUpdated;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
 class EventServiceProvider extends ServiceProvider
@@ -15,5 +18,7 @@ class EventServiceProvider extends ServiceProvider
         'eloquent.created*' => [DispatchWebhooks::class],
         'eloquent.deleted*' => [DispatchWebhooks::class],
         'eloquent.updated*' => [DispatchWebhooks::class],
+        RecordCreated::class => [AdminActivityListener::class],
+        RecordUpdated::class => [AdminActivityListener::class],
     ];
 }

--- a/app/Providers/Filament/FilamentServiceProvider.php
+++ b/app/Providers/Filament/FilamentServiceProvider.php
@@ -4,12 +4,14 @@ namespace App\Providers\Filament;
 
 use App\Enums\CustomizationKey;
 use App\Enums\TablerIcon;
+use App\Facades\Activity;
 use Filament\Actions\Action;
 use Filament\Actions\CreateAction;
 use Filament\Actions\DeleteAction;
 use Filament\Actions\EditAction;
 use Filament\Actions\View\ActionsIconAlias;
 use Filament\Actions\ViewAction;
+use Filament\Facades\Filament;
 use Filament\Forms\Components\Field;
 use Filament\Forms\Components\KeyValue;
 use Filament\Forms\Components\Repeater;
@@ -29,8 +31,10 @@ use Filament\Support\View\SupportIconAlias;
 use Filament\Tables\View\TablesIconAlias;
 use Filament\View\PanelsIconAlias;
 use Filament\View\PanelsRenderHook;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Facades\Blade;
 use Illuminate\Support\ServiceProvider;
+use Illuminate\Support\Str;
 use Livewire\Component;
 use Livewire\Livewire;
 
@@ -132,6 +136,18 @@ class FilamentServiceProvider extends ServiceProvider
                 $action->iconButton();
                 $action->iconSize(IconSize::ExtraLarge);
             }
+
+            $action->before(function (Model $record) {
+                if (Filament::getCurrentPanel()?->getId() !== 'admin') {
+                    return;
+                }
+
+                $slug = Str::kebab(class_basename($record));
+
+                Activity::event("admin:$slug.delete")
+                    ->subject($record)
+                    ->log();
+            });
         });
 
         CreateAction::configureUsing(function (CreateAction $action) {

--- a/lang/en/activity.php
+++ b/lang/en/activity.php
@@ -122,4 +122,51 @@ return [
         ],
         'crashed' => 'Server crashed',
     ],
+    'admin' => [
+        'user' => [
+            'create' => 'Created user <b>:username</b>',
+            'update' => 'Updated user <b>:username</b>',
+            'delete' => 'Deleted user <b>:username</b>',
+        ],
+        'server' => [
+            'create' => 'Created server <b>:name</b>',
+            'update' => 'Updated server <b>:name</b>',
+            'delete' => 'Deleted server <b>:name</b>',
+        ],
+        'node' => [
+            'create' => 'Created node <b>:name</b>',
+            'update' => 'Updated node <b>:name</b>',
+            'delete' => 'Deleted node <b>:name</b>',
+        ],
+        'egg' => [
+            'create' => 'Created egg <b>:name</b>',
+            'update' => 'Updated egg <b>:name</b>',
+            'delete' => 'Deleted egg <b>:name</b>',
+        ],
+        'role' => [
+            'create' => 'Created role <b>:name</b>',
+            'update' => 'Updated role <b>:name</b>',
+            'delete' => 'Deleted role <b>:name</b>',
+        ],
+        'database-host' => [
+            'create' => 'Created database host <b>:name</b>',
+            'update' => 'Updated database host <b>:name</b>',
+            'delete' => 'Deleted database host <b>:name</b>',
+        ],
+        'mount' => [
+            'create' => 'Created mount <b>:name</b>',
+            'update' => 'Updated mount <b>:name</b>',
+            'delete' => 'Deleted mount <b>:name</b>',
+        ],
+        'webhook-configuration' => [
+            'create' => 'Created webhook <b>:description</b>',
+            'update' => 'Updated webhook <b>:description</b>',
+            'delete' => 'Deleted webhook <b>:description</b>',
+        ],
+        'api-key' => [
+            'create' => 'Created API key',
+            'update' => 'Updated API key',
+            'delete' => 'Deleted API key',
+        ],
+    ],
 ];

--- a/tests/Filament/Admin/AdminActivityListenerTest.php
+++ b/tests/Filament/Admin/AdminActivityListenerTest.php
@@ -1,0 +1,146 @@
+<?php
+
+use App\Events\ActivityLogged;
+use App\Filament\Admin\Resources\Eggs\Pages\CreateEgg;
+use App\Filament\Admin\Resources\Eggs\Pages\EditEgg;
+use App\Filament\Admin\Resources\Nodes\Pages\CreateNode;
+use App\Filament\Admin\Resources\Nodes\Pages\EditNode;
+use App\Listeners\AdminActivityListener;
+use App\Models\Egg;
+use App\Models\Node;
+use App\Models\Role;
+use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Event;
+
+function pageInstance(string $class): object
+{
+    return (new ReflectionClass($class))->newInstanceWithoutConstructor();
+}
+
+beforeEach(function () {
+    [$this->admin] = generateTestAccount([]);
+    $this->admin = $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+
+    Filament::setCurrentPanel('admin');
+});
+
+it('logs create activity for an egg', function () {
+    $egg = Egg::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, ['name' => 'Test Egg'], pageInstance(CreateEgg::class));
+
+    $this->assertActivityLogged('admin:egg.create');
+});
+
+it('logs update activity for an egg', function () {
+    $egg = Egg::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, ['name' => 'Updated Egg'], pageInstance(EditEgg::class));
+
+    $this->assertActivityLogged('admin:egg.update');
+});
+
+it('logs create activity for a node', function () {
+    $node = Node::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($node, ['name' => 'Test Node'], pageInstance(CreateNode::class));
+
+    $this->assertActivityLogged('admin:node.create');
+});
+
+it('logs update activity for a node', function () {
+    $node = Node::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($node, ['name' => 'Updated Node'], pageInstance(EditNode::class));
+
+    $this->assertActivityLogged('admin:node.update');
+});
+
+it('does not log activity for non-admin panels', function () {
+    Filament::setCurrentPanel('app');
+
+    $egg = Egg::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, ['name' => 'Test'], pageInstance(CreateEgg::class));
+
+    Event::assertNotDispatched(ActivityLogged::class);
+});
+
+it('sets the record as the activity subject', function () {
+    $egg = Egg::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, ['name' => 'Test'], pageInstance(CreateEgg::class));
+
+    $this->assertActivityFor('admin:egg.create', $this->admin, $egg);
+});
+
+it('redacts sensitive fields from activity properties', function () {
+    $egg = Egg::first();
+
+    $data = [
+        'name' => 'Visible',
+        'password' => 'should-be-redacted',
+        'password_confirmation' => 'should-be-redacted',
+        'token' => 'should-be-redacted',
+        'secret' => 'should-be-redacted',
+        'api_key' => 'should-be-redacted',
+    ];
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, $data, pageInstance(EditEgg::class));
+
+    Event::assertDispatched(ActivityLogged::class, function (ActivityLogged $event) {
+        $properties = $event->model->properties;
+
+        expect($properties)->toHaveKey('name', 'Visible')
+            ->not->toHaveKey('password')
+            ->not->toHaveKey('password_confirmation')
+            ->not->toHaveKey('token')
+            ->not->toHaveKey('secret')
+            ->not->toHaveKey('api_key');
+
+        return true;
+    });
+});
+
+it('redacts sensitive fields in nested arrays', function () {
+    $egg = Egg::first();
+
+    $data = [
+        'name' => 'Visible',
+        'nested' => [
+            'safe' => 'value',
+            'password' => 'should-be-redacted',
+            'token' => 'should-be-redacted',
+        ],
+    ];
+
+    $listener = new AdminActivityListener();
+    $listener->handle($egg, $data, pageInstance(EditEgg::class));
+
+    Event::assertDispatched(ActivityLogged::class, function (ActivityLogged $event) {
+        $properties = $event->model->properties;
+
+        expect($properties['nested'])->toHaveKey('safe', 'value')
+            ->not->toHaveKey('password')
+            ->not->toHaveKey('token');
+
+        return true;
+    });
+});
+
+it('generates kebab-case event names from model class names', function () {
+    $node = Node::first();
+
+    $listener = new AdminActivityListener();
+    $listener->handle($node, ['name' => 'Test'], pageInstance(CreateNode::class));
+
+    $this->assertActivityLogged('admin:node.create');
+});


### PR DESCRIPTION
Log create, update, and delete actions performed in the admin panel using Filament's RecordCreated/RecordUpdated events and a DeleteAction before() hook. Sensitive fields (passwords, tokens) are redacted from stored properties.

Resolves #1585