### PR TITLE
Allow Caddy to bind privileged ports as www-data

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -68,6 +68,11 @@ RUN apk add --no-cache \
     # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
+# Allow Caddy to bind privileged ports (80/443) as www-data, including under network_mode: host
+RUN apk add --no-cache --virtual .setcap-deps libcap \
+    && setcap cap_net_bind_service+ep /usr/sbin/caddy \
+    && apk del .setcap-deps
+
 # Copy composer binary for runtime plugin dependency management
 COPY --from=composer /usr/local/bin/composer /usr/local/bin/composer
 COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -73,6 +73,11 @@ RUN apk add --no-cache \
     # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
+# Allow Caddy to bind privileged ports (80/443) as www-data, including under network_mode: host
+RUN apk add --no-cache --virtual .setcap-deps libcap \
+    && setcap cap_net_bind_service+ep /usr/sbin/caddy \
+    && apk del .setcap-deps
+
 # Copy composer binary for runtime plugin dependency management
 COPY --from=composer /usr/local/bin/composer /usr/local/bin/composer
 COPY --chown=root:www-data --chmod=770 --from=composerbuild /build .


### PR DESCRIPTION
This adds the `cap_net_bind_service` file capability to the Caddy binary, letting it bind `:80`/`:443` as the unprivileged `www-data` user the image already drops to.

```dockerfile
RUN apk add --no-cache --virtual .setcap-deps libcap \
    && setcap cap_net_bind_service+ep /usr/sbin/caddy \
    && apk del .setcap-deps
```

This would allow us to listen on port 443 when using host networking. 

The reason to want host networking is that bridge mode obscures real client IPs and doesn't do public IPv6 without significant Docker daemon reconfiguration. The former additionally means that in access logs rather than the real user IP showing up, it will show Docker's internal virtual IP address, which is the main reason I want to pitch this PR. 

Another way to achieve the same is to run the entire container as root, but that would defeat the existing `USER www-data` directive, and basically boils down to deploying a nuke to squash a mosquito. 

People who are using bridge networking are unaffected by this change; they already have privilege over `:80`/`:443` by default. 
