### PR TITLE
Fix translations workflow not opening PRs

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
+        with:
+          persist-credentials: false
 
       - name: Download Translations from Crowdin
         uses: crowdin/github-action@v2


### PR DESCRIPTION
The weekly Crowdin workflow has been failing on every run. Download + Pint both work fine, it just dies on the Create Pull Request step.

Two things were going on:

1. checkout@v6 keeps its auth header around, and create-pull-request adds its own on top, so git ends up sending the Authorization header twice and GitHub 400s with `Duplicate header: "Authorization"`. Setting `persist-credentials: false` on checkout sorts it out (see peter-evans/create-pull-request#4272). That's the only change in here.

2. Before it even got that far it would've hit a 403 since Actions wasn't allowed to open PRs. Already flipped that on in the org/repo settings.

Once this is merged I'll kick off a manual run to make sure it actually opens the PR now.