### PR TITLE
Bump create-pull-request to v8 in the translations workflow

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -38,7 +38,7 @@ jobs:
         uses: aglipanci/laravel-pint-action@8eedec46a1856977c41667f9c66d5562fa3f9c08 # 2.4
 
       - name: Create Pull Request
-        uses: peter-evans/create-pull-request@c5a7806660adbe173f04e3e038b0ccdcd758773c # v6
+        uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           commit-message: 'chore: update translations and format with pint'


### PR DESCRIPTION
Follow-up to the last translations workflow fix. Now that the auth and permissions stuff is sorted, the Create Pull Request step actually runs and hits a third thing:

```
error: The following untracked working tree files would be overwritten by checkout:
	lang/ja/command/messages.php
	...
Aborting
```

The old v6.1.0 pin leaves the freshly downloaded translation files untracked while it builds its temp commit, so any time Crowdin pulls in a brand new language file the internal `git checkout -B` on the PR branch bails. That's why it never managed to open a PR.

Bumping to v8.1.1 fixes the temp-branch handling and runs on Node 24 (so the Node 20 deprecation warning goes away too). The inputs we use here (token/commit-message/title/body/branch/base) haven't changed across v6 -> v8, and the only v8 requirement (runner >= 2.327.1) is already met by the hosted runners.

I'll trigger a manual run after this is merged to make sure it opens the PR.