### PR TITLE
Fix root-owned files breaking the translations PR step

### DIFF
--- a/.github/workflows/download-translations.yml
+++ b/.github/workflows/download-translations.yml
@@ -37,6 +37,12 @@ jobs:
       - name: Run Laravel Pint
         uses: aglipanci/laravel-pint-action@8eedec46a1856977c41667f9c66d5562fa3f9c08 # 2.4
 
+      # The Crowdin and Pint steps run in Docker as root, so new translation
+      # files land owned by root. Reclaim them so the host-side git operations
+      # in create-pull-request can manage the working tree.
+      - name: Fix file ownership
+        run: sudo chown -R "$(id -u):$(id -g)" "${{ github.workspace }}"
+
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5f6978faf089d4d20b00c7766989d076bb2fc7f1 # v8.1.1
         with:


### PR DESCRIPTION
Picking up where the v8 bump left off. The Create Pull Request step still bails with:

```
error: The following untracked working tree files would be overwritten by checkout:
	lang/ja/server/console.php
	lang/tr/server/network.php
	...
```

Dug into the full git trace this time and the version was never the problem. The action commits the changes to a temp branch, switches back to main (which should drop the new files), then checks the temp branch back out. The new files survive that switch as untracked, which only happens if git couldn't delete them.

Reason: Crowdin (and Pint) run in Docker as root, so the new translation files land owned by root. They're always in brand new subdirs that don't exist in the repo yet (lang/ja/server, lang/ja/command, lang/tr/server), which is why only new languages trip it. create-pull-request runs on the host as the runner user and can't remove root-owned files, so they stick around and collide.

Fix is just to chown the workspace back to the runner before the PR step. Hosted runners have passwordless sudo so this is the standard workaround for Docker-based actions.

Will run the workflow manually once merged to confirm it finally opens the PR.