### PR TITLE
fix(admin): fix cpu pinning showing as disabled when thread 0 is configured

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -390,7 +390,7 @@ class EditServer extends EditRecord
                                                 ->label(trans('admin/server.cpu_pin'))->inlineLabel()->inline()
                                                 ->default(0)
                                                 ->afterStateUpdated(fn (Set $set) => $set('threads', []))
-                                                ->formatStateUsing(fn (Get $get) => !empty($get('threads')))
+                                                ->formatStateUsing(fn (Get $get) => filled($get('threads')))
                                                 ->live()
                                                 ->stateCast(new BooleanStateCast(false, true))
                                                 ->options([


### PR DESCRIPTION
## Description
This PR fixes an issue where setting CPU pinning to core `0` gets incorrectly displayed as "disabled" upon page refresh.

The bug is caused by using `!empty($get('threads'))` in PHP, where `empty("0")` evaluates to `true`. This has been corrected by using Laravel's `filled()` helper instead, which correctly treats `"0"` and `0` as non-empty.

Ref: https://github.com/pelican-dev/panel/issues/2385
