### PR TITLE
feat: support schedule cron input in user timezone (#1228)

### DIFF
--- a/app/Filament/Server/Resources/Schedules/Pages/CreateSchedule.php
+++ b/app/Filament/Server/Resources/Schedules/Pages/CreateSchedule.php
@@ -57,7 +57,8 @@ class CreateSchedule extends CreateRecord
                 $data['cron_hour'],
                 $data['cron_day_of_month'],
                 $data['cron_month'],
-                $data['cron_day_of_week']
+                $data['cron_day_of_week'],
+                $data['timezone'] ?? null
             );
         }
 

--- a/app/Filament/Server/Resources/Schedules/Pages/EditSchedule.php
+++ b/app/Filament/Server/Resources/Schedules/Pages/EditSchedule.php
@@ -42,7 +42,8 @@ class EditSchedule extends EditRecord
             $data['cron_hour'],
             $data['cron_day_of_month'],
             $data['cron_month'],
-            $data['cron_day_of_week']
+            $data['cron_day_of_week'],
+            $data['timezone'] ?? null
         );
 
         return $data;

--- a/app/Filament/Server/Resources/Schedules/ScheduleResource.php
+++ b/app/Filament/Server/Resources/Schedules/ScheduleResource.php
@@ -100,15 +100,33 @@ class ScheduleResource extends Resource
                     ->visibleOn('view'),
                 Section::make(trans('server/schedule.cron'))
                     ->description(function (Get $get) {
+                        $timezone = $get('timezone') ?: (user()->timezone ?? 'UTC');
                         try {
-                            $nextRun = Utilities::getScheduleNextRunDate($get('cron_minute'), $get('cron_hour'), $get('cron_day_of_month'), $get('cron_month'), $get('cron_day_of_week'))->timezone(user()->timezone ?? 'UTC');
+                            $nextRun = Utilities::getScheduleNextRunDate(
+                                $get('cron_minute'),
+                                $get('cron_hour'),
+                                $get('cron_day_of_month'),
+                                $get('cron_month'),
+                                $get('cron_day_of_week'),
+                                $timezone
+                            )->timezone($timezone);
                         } catch (Exception) {
                             $nextRun = trans('server/schedule.invalid');
                         }
 
-                        return new HtmlString(trans('server/schedule.cron_body') . '<br>' . trans('server/schedule.cron_timezone', ['timezone' => user()->timezone ?? 'UTC', 'next_run' => $nextRun]));
+                        return new HtmlString(trans('server/schedule.cron_body') . '<br>' . trans('server/schedule.cron_timezone', ['timezone' => $timezone, 'next_run' => $nextRun]));
                     })
                     ->schema([
+                        Select::make('timezone')
+                            ->label(trans('server/schedule.timezone'))
+                            ->prefixIcon(TablerIcon::ClockPin)
+                            ->required()
+                            ->default(fn () => user()->timezone ?? 'UTC')
+                            ->selectablePlaceholder(false)
+                            ->options(fn () => collect(\DateTimeZone::listIdentifiers())->mapWithKeys(fn ($tz) => [$tz => $tz]))
+                            ->searchable()
+                            ->live()
+                            ->columnSpanFull(),
                         Actions::make([
                             CronPresetAction::make('exclude_hourly')
                                 ->label(trans('server/schedule.time.hourly'))
@@ -379,10 +397,10 @@ class ScheduleResource extends Resource
         ];
     }
 
-    public static function getNextRun(string $minute, string $hour, string $dayOfMonth, string $month, string $dayOfWeek): Carbon
+    public static function getNextRun(string $minute, string $hour, string $dayOfMonth, string $month, string $dayOfWeek, ?string $timezone = null): Carbon
     {
         try {
-            return Utilities::getScheduleNextRunDate($minute, $hour, $dayOfMonth, $month, $dayOfWeek);
+            return Utilities::getScheduleNextRunDate($minute, $hour, $dayOfMonth, $month, $dayOfWeek, $timezone);
         } catch (Exception) {
             Notification::make()
                 ->title(trans('server/schedule.notification_invalid_cron'))

--- a/app/Helpers/Utilities.php
+++ b/app/Helpers/Utilities.php
@@ -38,11 +38,11 @@ class Utilities
      *
      * @throws Exception
      */
-    public static function getScheduleNextRunDate(string $minute, string $hour, string $dayOfMonth, string $month, string $dayOfWeek): Carbon
+    public static function getScheduleNextRunDate(string $minute, string $hour, string $dayOfMonth, string $month, string $dayOfWeek, ?string $timezone = null): Carbon
     {
         return Carbon::instance((new CronExpression(
             sprintf('%s %s %s %s %s', $minute, $hour, $dayOfMonth, $month, $dayOfWeek)
-        ))->getNextRunDate(now('UTC')));
+        ))->getNextRunDate(now($timezone ?: 'UTC')))->setTimezone('UTC');
     }
 
     public static function checked(string $name, mixed $default): string

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
@@ -73,6 +73,7 @@ class ScheduleController extends ClientApiController
             'cron_day_of_month' => $request->input('day_of_month'),
             'cron_hour' => $request->input('hour'),
             'cron_minute' => $request->input('minute'),
+            'timezone' => $request->input('timezone'),
             'is_active' => (bool) $request->input('is_active'),
             'only_when_online' => (bool) $request->input('only_when_online'),
             'next_run_at' => $this->getNextRunAt($request),
@@ -129,6 +130,7 @@ class ScheduleController extends ClientApiController
             'cron_day_of_month' => $request->input('day_of_month'),
             'cron_hour' => $request->input('hour'),
             'cron_minute' => $request->input('minute'),
+            'timezone' => $request->input('timezone'),
             'is_active' => $active,
             'only_when_online' => (bool) $request->input('only_when_online'),
             'next_run_at' => $this->getNextRunAt($request),
@@ -196,7 +198,8 @@ class ScheduleController extends ClientApiController
                 $request->input('hour'),
                 $request->input('day_of_month'),
                 $request->input('month'),
-                $request->input('day_of_week')
+                $request->input('day_of_week'),
+                $request->input('timezone')
             );
         } catch (Exception) {
             throw new DisplayException('The cron data provided does not evaluate to a valid expression.');

--- a/app/Http/Requests/Api/Client/Servers/Schedules/StoreScheduleRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Schedules/StoreScheduleRequest.php
@@ -25,6 +25,7 @@ class StoreScheduleRequest extends ViewScheduleRequest
             'day_of_month' => $rules['cron_day_of_month'],
             'month' => $rules['cron_month'],
             'day_of_week' => $rules['cron_day_of_week'],
+            'timezone' => array_merge(['nullable', 'string'], $rules['timezone'] ?? []),
         ];
     }
 }

--- a/app/Models/Schedule.php
+++ b/app/Models/Schedule.php
@@ -83,6 +83,7 @@ class Schedule extends Model implements Validatable
         'cron_day_of_month',
         'cron_hour',
         'cron_minute',
+        'timezone',
         'is_active',
         'is_processing',
         'only_when_online',
@@ -97,6 +98,7 @@ class Schedule extends Model implements Validatable
         'cron_day_of_month' => '*',
         'cron_hour' => '*',
         'cron_minute' => '*',
+        'timezone' => null,
         'is_active' => true,
         'is_processing' => false,
         'only_when_online' => false,
@@ -111,6 +113,7 @@ class Schedule extends Model implements Validatable
         'cron_day_of_month' => ['required', 'string'],
         'cron_hour' => ['required', 'string'],
         'cron_minute' => ['required', 'string'],
+        'timezone' => ['nullable', 'string'],
         'is_active' => ['boolean'],
         'is_processing' => ['boolean'],
         'only_when_online' => ['boolean'],
@@ -145,7 +148,7 @@ class Schedule extends Model implements Validatable
      */
     public function getNextRunDate(): string
     {
-        return Utilities::getScheduleNextRunDate($this->cron_minute, $this->cron_hour, $this->cron_day_of_month, $this->cron_month, $this->cron_day_of_week)->toDateTimeString();
+        return Utilities::getScheduleNextRunDate($this->cron_minute, $this->cron_hour, $this->cron_day_of_month, $this->cron_month, $this->cron_day_of_week, $this->timezone)->toDateTimeString();
     }
 
     /**

--- a/app/Services/Schedules/Sharing/ScheduleExporterService.php
+++ b/app/Services/Schedules/Sharing/ScheduleExporterService.php
@@ -22,6 +22,7 @@ class ScheduleExporterService
             'cron_day_of_month' => $schedule->cron_day_of_month,
             'cron_month' => $schedule->cron_month,
             'cron_day_of_week' => $schedule->cron_day_of_week,
+            'timezone' => $schedule->timezone,
 
             'tasks' => $schedule->tasks->map(function (Task $task) {
                 return [

--- a/app/Services/Schedules/Sharing/ScheduleImporterService.php
+++ b/app/Services/Schedules/Sharing/ScheduleImporterService.php
@@ -36,6 +36,7 @@ class ScheduleImporterService
             $dayOfMonth = Arr::get($parsed, 'cron_day_of_month', '*');
             $month = Arr::get($parsed, 'cron_month', '*');
             $dayOfWeek = Arr::get($parsed, 'cron_day_of_week', '*');
+            $timezone = Arr::get($parsed, 'timezone');
 
             $schedule = Schedule::create([
                 'server_id' => $server->id,
@@ -47,7 +48,8 @@ class ScheduleImporterService
                 'cron_day_of_month' => $dayOfMonth,
                 'cron_month' => $month,
                 'cron_day_of_week' => $dayOfWeek,
-                'next_run_at' => Utilities::getScheduleNextRunDate($minute, $hour, $dayOfMonth, $month, $dayOfWeek),
+                'timezone' => $timezone,
+                'next_run_at' => Utilities::getScheduleNextRunDate($minute, $hour, $dayOfMonth, $month, $dayOfWeek, $timezone),
             ]);
 
             foreach (Arr::get($parsed, 'tasks', []) as $task) {

--- a/app/Transformers/Api/Client/ScheduleTransformer.php
+++ b/app/Transformers/Api/Client/ScheduleTransformer.php
@@ -37,6 +37,7 @@ class ScheduleTransformer extends BaseClientTransformer
             ],
             'is_active' => $model->is_active,
             'is_processing' => $model->is_processing,
+            'timezone' => $model->timezone,
             'only_when_online' => $model->only_when_online,
             'last_run_at' => $model->last_run_at?->toAtomString(),
             'next_run_at' => $model->next_run_at?->toAtomString(),

--- a/database/migrations/2026_06_28_210800_add_timezone_to_schedules_table.php
+++ b/database/migrations/2026_06_28_210800_add_timezone_to_schedules_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->string('timezone')->nullable()->after('cron_minute');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('schedules', function (Blueprint $table) {
+            $table->dropColumn('timezone');
+        });
+    }
+};

--- a/lang/en/server/schedule.php
+++ b/lang/en/server/schedule.php
@@ -29,8 +29,9 @@ return [
     'only_online_hint' => 'Only execute this schedule when the server is in a running state.',
     'enabled' => 'Enable Schedule?',
     'enabled_hint' => 'This schedule will be executed automatically if enabled.',
+    'timezone' => 'Timezone',
 
-    'cron_body' => 'Please keep in mind that the cron inputs below always assume UTC.',
+    'cron_body' => 'The cron inputs below are evaluated in the timezone configured above.',
     'cron_timezone' => 'Next run in your timezone (:timezone): <b> :next_run </b>',
 
     'invalid' => 'Invalid',

--- a/lang/zh_TW/server/schedule.php
+++ b/lang/zh_TW/server/schedule.php
@@ -29,8 +29,9 @@ return [
     'only_online_hint' => '僅在伺服器處於執行狀態時執行此排程。',
     'enabled' => '啟用排程？',
     'enabled_hint' => '如果啟用，此排程將會自動執行。',
+    'timezone' => '時區',
 
-    'cron_body' => '請注意：下方的 Cron 排程輸入一律以 UTC 時區為準。',
+    'cron_body' => '請注意：下方的 Cron 排程輸入將會以您上方設定的時區來進行評估。',
     'cron_timezone' => '在您的時區 (:timezone) 下次執行時間：<b> :next_run </b>',
 
     'invalid' => '無效',


### PR DESCRIPTION
## Description
This PR addresses issue #1228 by allowing users to define and display server schedules using a custom timezone instead of forcing UTC globally on the frontend. 

## Key Changes
- **Database Schema**: Added a nullable `timezone` column to the `schedules` table.
- **Form UI**: Introduced a `timezone` dropdown (defaulting to the user's timezone) in the Filament schedule form.
- **Cron evaluation**: Updated the scheduler calculation helper (`Utilities::getScheduleNextRunDate`) to evaluate the next run date relative to the configured timezone, while storing the resulting `next_run_at` timestamp in UTC in the backend database.
- **API & Exporter**: Handled timezone field in API requests (`StoreScheduleRequest`/`ScheduleController`), fractal transformers (`ScheduleTransformer`), and import/export service layers.
- **Localization**: Updated key translations (`en`, `zh_TW`) for cron input timezone guidance.

Fixes #1228 