### PR TITLE
Add IO as a setting.

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
@@ -665,6 +665,7 @@ class CreateServer extends CreateRecord
                                         ->hidden(fn (Get $get) => $get('io_toggle'))
                                         ->label(trans('admin/server.value'))->inlineLabel()
                                         ->required()
+                                        ->default(500)
                                         ->hintIcon(TablerIcon::QuestionMark, trans('admin/server.io_tooltip'))
                                         ->columnSpan(2)
                                         ->numeric()
@@ -683,11 +684,6 @@ class CreateServer extends CreateRecord
                             'lg' => 3,
                         ])
                         ->schema([
-                            Hidden::make('io')
-                                ->helperText('The IO performance relative to other running containers')
-                                ->label('Block IO Proportion')
-                                ->default(500),
-
                             Grid::make()
                                 ->columns(4)
                                 ->columnSpanFull()

--- a/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
@@ -32,6 +32,7 @@ use Filament\Resources\Pages\CreateRecord;
 use Filament\Schemas\Components\Fieldset;
 use Filament\Schemas\Components\Grid;
 use Filament\Schemas\Components\Section;
+use Filament\Schemas\Components\StateCasts\BooleanStateCast;
 use Filament\Schemas\Components\Utilities\Get;
 use Filament\Schemas\Components\Utilities\Set;
 use Filament\Schemas\Components\Wizard;
@@ -637,6 +638,38 @@ class CreateServer extends CreateRecord
                                         ->columnSpan(2)
                                         ->numeric()
                                         ->minValue(0),
+                                ]),
+                            Grid::make()
+                                ->columns(4)
+                                ->columnSpanFull()
+                                ->schema([
+                                    ToggleButtons::make('io_toggle')
+                                        ->dehydrated()
+                                        ->label(trans('admin/server.io'))->inlineLabel()->inline()
+                                        ->live()
+                                        ->afterStateUpdated(fn (Set $set) => $set('disk', 0))
+                                        ->formatStateUsing(fn (Get $get) => $get('disk') == 0)
+                                        ->stateCast(new BooleanStateCast(false, true))
+                                        ->options([
+                                            1 => trans('admin/server.default'),
+                                            0 => trans('admin/server.custom'),
+                                        ])
+                                        ->colors([
+                                            1 => 'primary',
+                                            0 => 'warning',
+                                        ])
+                                        ->columnSpan(2),
+
+                                    TextInput::make('io')
+                                        ->dehydratedWhenHidden()
+                                        ->hidden(fn (Get $get) => $get('io_toggle'))
+                                        ->label(trans('admin/server.value'))->inlineLabel()
+                                        ->required()
+                                        ->hintIcon(TablerIcon::QuestionMark, trans('admin/server.io_tooltip'))
+                                        ->columnSpan(2)
+                                        ->numeric()
+                                        ->minValue(0)
+                                        ->maxValue(1024),
                                 ]),
 
                         ]),

--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -367,6 +367,38 @@ class EditServer extends EditRecord
                                         ->numeric()
                                         ->minValue(0),
                                 ]),
+                            Grid::make()
+                                ->columns(4)
+                                ->columnSpanFull()
+                                ->schema([
+                                    ToggleButtons::make('io_toggle')
+                                        ->dehydrated()
+                                        ->label(trans('admin/server.io'))->inlineLabel()->inline()
+                                        ->live()
+                                        ->afterStateUpdated(fn (Set $set) => $set('disk', 0))
+                                        ->formatStateUsing(fn (Get $get) => $get('disk') == 0)
+                                        ->stateCast(new BooleanStateCast(false, true))
+                                        ->options([
+                                            1 => trans('admin/server.default'),
+                                            0 => trans('admin/server.custom'),
+                                        ])
+                                        ->colors([
+                                            1 => 'primary',
+                                            0 => 'warning',
+                                        ])
+                                        ->columnSpan(2),
+
+                                    TextInput::make('io')
+                                        ->dehydratedWhenHidden()
+                                        ->hidden(fn (Get $get) => $get('io_toggle'))
+                                        ->label(trans('admin/server.value'))->inlineLabel()
+                                        ->required()
+                                        ->hintIcon(TablerIcon::QuestionMark, trans('admin/server.io_tooltip'))
+                                        ->columnSpan(2)
+                                        ->numeric()
+                                        ->minValue(0)
+                                        ->maxValue(1024),
+                                ]),
                         ]),
 
                     Fieldset::make(trans('admin/server.advanced_limits'))

--- a/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/EditServer.php
@@ -492,10 +492,6 @@ class EditServer extends EditRecord
                                         ->integer(),
                                 ]),
 
-                            Hidden::make('io')
-                                ->helperText('The IO performance relative to other running containers')
-                                ->label('Block IO Proportion'),
-
                             Grid::make()
                                 ->columns(4)
                                 ->columnSpanFull()

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -152,4 +152,9 @@ return [
     'notes' => 'Notes',
     'no_notes' => 'No Notes',
     'none' => 'None',
+    'io' => 'I/O',
+    'default' => 'Default',
+    'custom' => 'Custom',
+    'value' => 'Value',
+    'io_tooltip' => 'Controls how the server is prioritized for disk access. 1 lowest, 1024 highest.',
 ];

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -156,5 +156,5 @@ return [
     'default' => 'Default',
     'custom' => 'Custom',
     'value' => 'Value',
-    'io_tooltip' => 'Controls how the server is prioritized for disk access. 1 lowest, 1024 highest.',
+    'io_tooltip' => 'The IO performance relative to other running containers on the same node.',
 ];

--- a/lang/en/admin/server.php
+++ b/lang/en/admin/server.php
@@ -152,7 +152,7 @@ return [
     'notes' => 'Notes',
     'no_notes' => 'No Notes',
     'none' => 'None',
-    'io' => 'I/O',
+    'io' => 'IO',
     'default' => 'Default',
     'custom' => 'Custom',
     'value' => 'Value',


### PR DESCRIPTION
I understand that hardcoded I/O is on purpose for what I can remember. But the other day I had a docker that did not like I/O and I had to edit core files to make it 0. Would be nice to have it as a feature actually and not a hardcoded 500.
On this instance, I am not sure where to place it, so I accept requests to move it.
IO explanation was copied from old io component.