### PR TITLE
Fix activity log event filter query and add missing timestamp index

### DIFF
--- a/app/Filament/Server/Resources/Activities/ActivityResource.php
+++ b/app/Filament/Server/Resources/Activities/ActivityResource.php
@@ -133,7 +133,7 @@ class ActivityResource extends Resource
             ])
             ->filters([
                 SelectFilter::make('event')
-                    ->options(fn (Table $table) => $table->getQuery()->pluck('event', 'event')->unique()->sort())
+                    ->options(fn (Table $table) => $table->getQuery()->select('event')->distinct()->orderBy('event')->pluck('event', 'event'))
                     ->searchable()
                     ->preload(),
             ]);

--- a/database/migrations/2026_07_03_023804_add_index_to_activity_logs_timestamp.php
+++ b/database/migrations/2026_07_03_023804_add_index_to_activity_logs_timestamp.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->index('timestamp');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('activity_logs', function (Blueprint $table) {
+            $table->dropIndex(['timestamp']);
+        });
+    }
+};


### PR DESCRIPTION
This PR resolves issue where activity page timeouts (or loads for a long time) for servers with lots of activity.

Two small fixes in the activity log area:
- ActivityResource: event filter dropdown was pulling every row into memory and deduping/sorting in PHP. Switched to SELECT DISTINCT ... ORDER BY so the DB does the work. Same output, just faster on tables with a lot of activity.
- Added an index on activity_logs.timestamp — this column gets queried/sorted on constantly and had no index.