### PR TITLE
feat: redirect users to installer on fresh installations

### DIFF
--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -11,7 +11,7 @@ class RedirectIfNotInstalled
     /**
      * Handle an incoming request.
      *
-     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     * @param  Closure(Request): (Response)  $next
      */
     public function handle(Request $request, Closure $next): Response
     {

--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class RedirectIfNotInstalled
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        if (config('app.installed')) {
+            return $next($request);
+        }
+
+        if ($request->is('installer', 'installer/*', 'livewire/*')) {
+            return $next($request);
+        }
+
+        if ($request->expectsJson() || $request->is('api/*')) {
+            return response()->json(['error' => 'Installation incomplete.'], 503);
+        }
+
+        return redirect()->route('installer');
+    }
+}

--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -19,13 +19,6 @@ class RedirectIfNotInstalled
             return $next($request);
         }
 
-        if ($request->is('installer', 'installer/*', 'livewire/*', 'up')) {
-            return $next($request);
-        }
-
-        if ($request->expectsJson() || $request->is('api/*')) {
-            return response()->json(['error' => 'Installation incomplete.'], 503);
-        }
 
         return redirect()->route('installer');
     }

--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -19,7 +19,6 @@ class RedirectIfNotInstalled
             return $next($request);
         }
 
-
         return redirect()->route('installer');
     }
 }

--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -19,7 +19,7 @@ class RedirectIfNotInstalled
             return $next($request);
         }
 
-        if ($request->is('installer', 'installer/*', 'livewire/*')) {
+        if ($request->is('installer', 'installer/*', 'livewire/*', 'up')) {
             return $next($request);
         }
 

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -29,6 +29,8 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->redirectGuestsTo(fn () => route('filament.app.auth.login'));
 
+        $middleware->append(\App\Http\Middleware\RedirectIfNotInstalled::class);
+
         $middleware->web([
             LanguageMiddleware::class,
             SetSecurityHeaders::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -77,5 +77,6 @@ return Application::configure(basePath: dirname(__DIR__))
         ExceptionHandler::class => Handler::class,
     ])
     ->withExceptions(function (Exceptions $exceptions) {
+        //
     })
     ->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -30,9 +30,8 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->redirectGuestsTo(fn () => route('filament.app.auth.login'));
 
-        $middleware->append(RedirectIfNotInstalled::class);
-
         $middleware->web([
+            RedirectIfNotInstalled::class,
             LanguageMiddleware::class,
             SetSecurityHeaders::class,
         ]);
@@ -76,7 +75,5 @@ return Application::configure(basePath: dirname(__DIR__))
         Illuminate\Contracts\Console\Kernel::class => Kernel::class,
         ExceptionHandler::class => Handler::class,
     ])
-    ->withExceptions(function (Exceptions $exceptions) {
-        //
-    })
+    ->withExceptions(function (Exceptions $exceptions) {})
     ->create();

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,6 +13,7 @@ use App\Http\Middleware\LanguageMiddleware;
 use App\Http\Middleware\MaintenanceMiddleware;
 use App\Http\Middleware\PreventRequestForgery;
 use App\Http\Middleware\RedirectIfAuthenticated;
+use App\Http\Middleware\RedirectIfNotInstalled;
 use App\Http\Middleware\SetSecurityHeaders;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Application;
@@ -29,7 +30,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware) {
         $middleware->redirectGuestsTo(fn () => route('filament.app.auth.login'));
 
-        $middleware->append(\App\Http\Middleware\RedirectIfNotInstalled::class);
+        $middleware->append(RedirectIfNotInstalled::class);
 
         $middleware->web([
             LanguageMiddleware::class,
@@ -75,5 +76,6 @@ return Application::configure(basePath: dirname(__DIR__))
         Illuminate\Contracts\Console\Kernel::class => Kernel::class,
         ExceptionHandler::class => Handler::class,
     ])
-    ->withExceptions(function (Exceptions $exceptions) {})
+    ->withExceptions(function (Exceptions $exceptions) {
+    })
     ->create();

--- a/routes/base.php
+++ b/routes/base.php
@@ -4,4 +4,4 @@ use App\Livewire\Installer\PanelInstaller;
 use Illuminate\Support\Facades\Route;
 
 Route::get('installer', PanelInstaller::class)->name('installer')
-    ->withoutMiddleware(['auth']);
+    ->withoutMiddleware(['auth', \App\Http\Middleware\RedirectIfNotInstalled::class]);

--- a/routes/base.php
+++ b/routes/base.php
@@ -1,7 +1,8 @@
 <?php
 
+use App\Http\Middleware\RedirectIfNotInstalled;
 use App\Livewire\Installer\PanelInstaller;
 use Illuminate\Support\Facades\Route;
 
 Route::get('installer', PanelInstaller::class)->name('installer')
-    ->withoutMiddleware(['auth', \App\Http\Middleware\RedirectIfNotInstalled::class]);
+    ->withoutMiddleware(['auth', RedirectIfNotInstalled::class]);


### PR DESCRIPTION
Closes #2413 

#### What does this PR do?
This PR resolves an issue where a fresh installation (e.g. via Docker) throws a generic 500 error when visiting the root URL (`/`) or `/login` due to the uninitialized database. 

Instead of showing a generic error, this PR introduces a global `RedirectIfNotInstalled` middleware that automatically guides the operator to the `/installer` if the panel has not yet completed its first-run setup (`config('app.installed') === false`).

#### Implementation Details
- Added `App\Http\Middleware\RedirectIfNotInstalled` to gracefully intercept incoming requests.
- If the application is not installed:
  - Standard web requests are redirected to `route('installer')`.
  - API and JSON requests are rejected with a `503 Service Unavailable` response.
  - Required `/installer` and `/livewire/*` routes are explicitly allowed to proceed so the setup process functions correctly.
- Appended the middleware to the global stack in `bootstrap/app.php`.

#### How to Test
1. Set up a fresh instance (e.g., using the `ghcr.io/pelican-dev/panel:latest` Docker image) without completing the web installer.
2. Visit the root URL `https://panel.example.com/` or `https://panel.example.com/login`.
3. Verify that the application redirects you to `https://panel.example.com/installer` instead of showing a generic "Something went wrong" modal.
