### PR TITLE
fix #2435 handle missing event names in webhook dispatcher

### DIFF
--- a/app/Listeners/DispatchWebhooks.php
+++ b/app/Listeners/DispatchWebhooks.php
@@ -210,8 +210,12 @@ class DispatchWebhooks
         }
     }
 
-    protected function eventIsWatched(string $eventName): bool
+    protected function eventIsWatched(?string $eventName): bool
     {
+        if ($eventName === null) {
+            return false;
+        }
+
         $watchedEvents = cache()->rememberForever('watchedWebhooks', function () {
             return WebhookConfiguration::where('scope', WebhookScope::Global)
                 ->pluck('events')

--- a/app/Listeners/DispatchWebhooks.php
+++ b/app/Listeners/DispatchWebhooks.php
@@ -100,6 +100,10 @@ class DispatchWebhooks
     {
         $eventName = $activityLogged->model->event;
 
+        if ($eventName === null) {
+            return;
+        }
+
         if (!$activityLogged->isServerEvent()) {
             return;
         }
@@ -176,6 +180,10 @@ class DispatchWebhooks
     {
         $eventName = $activityLogged->model->event;
         $activityLoggedClass = ActivityLogged::class;
+
+        if ($eventName === null) {
+            return;
+        }
 
         $matchingHooks = collect();
 


### PR DESCRIPTION
Closes #2435 

#### What does this PR do?
This PR fixes a `500 Internal Server Error` that occurs when creating a database via the Client API (`/api/client/servers/{server}/databases`) while webhooks are enabled. 

Currently, the activity logged for database creation does not explicitly specify an event name, resulting in a `null` value. The `DispatchWebhooks` listener previously expected a strict `string`, causing a fatal `TypeError` when it attempted to evaluate the missing event name.

This fix makes `DispatchWebhooks::eventIsWatched()` more defensive by accepting a nullable string (`?string $eventName`) and treating a `null` value as a no-op (i.e. returning `false`). This prevents the application from crashing and allows the database creation request to complete successfully.

#### Implementation Details
- Updated the signature of `App\Listeners\DispatchWebhooks::eventIsWatched()` to `?string $eventName`.
- Added an early return `if ($eventName === null) { return false; }` to safely bypass webhook dispatching for activities that lack a defined event name.

#### How to Test
1. Ensure Webhooks are enabled on the panel.
2. Make a POST request to the API to create a database on a server (`/api/client/servers/{server}/databases`).
3. Verify that the request completes successfully with a `200` series response and that the database is created, rather than throwing a 500 error.
