### PR TITLE
Fix PHPStan return.type errors

### DIFF
--- a/app/Console/Commands/Egg/NormalizeEggCommand.php
+++ b/app/Console/Commands/Egg/NormalizeEggCommand.php
@@ -112,7 +112,7 @@ class NormalizeEggCommand extends Command
 
     private static function replaceExtension(string $path): string
     {
-        return preg_replace('/^(.*\.)(?:yml|json|yaml)$/', '$1yaml', $path);
+        return preg_replace('/^(.*\.)(?:yml|json|yaml)$/', '$1yaml', $path) ?? $path;
     }
 
     /**

--- a/app/Extensions/Captcha/Schemas/Turnstile/TurnstileSchema.php
+++ b/app/Extensions/Captcha/Schemas/Turnstile/TurnstileSchema.php
@@ -21,7 +21,7 @@ class TurnstileSchema extends BaseSchema implements CaptchaSchemaInterface
 
     public function isEnabled(): bool
     {
-        return env('CAPTCHA_TURNSTILE_ENABLED', false);
+        return (bool) env('CAPTCHA_TURNSTILE_ENABLED', false);
     }
 
     public function getFormComponent(): Component

--- a/app/Extensions/OAuth/Schemas/AuthentikSchema.php
+++ b/app/Extensions/OAuth/Schemas/AuthentikSchema.php
@@ -73,11 +73,11 @@ final class AuthentikSchema extends OAuthSchema
 
     public function getName(): string
     {
-        return env('OAUTH_AUTHENTIK_DISPLAY_NAME', 'Authentik');
+        return (string) env('OAUTH_AUTHENTIK_DISPLAY_NAME', 'Authentik');
     }
 
     public function getHexColor(): string
     {
-        return env('OAUTH_AUTHENTIK_DISPLAY_COLOR', '#fd4b2d');
+        return (string) env('OAUTH_AUTHENTIK_DISPLAY_COLOR', '#fd4b2d');
     }
 }

--- a/app/Extensions/OAuth/Schemas/OAuthSchema.php
+++ b/app/Extensions/OAuth/Schemas/OAuthSchema.php
@@ -120,20 +120,20 @@ abstract class OAuthSchema implements OAuthSchemaInterface
 
     public function isEnabled(): bool
     {
-        return env($this->getConfigKey(), false);
+        return (bool) env($this->getConfigKey(), false);
     }
 
     public function shouldCreateMissingUser(OAuthUser $user): bool
     {
         $id = Str::upper($this->getId());
 
-        return env("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS", false);
+        return (bool) env("OAUTH_{$id}_SHOULD_CREATE_MISSING_USERS", false);
     }
 
     public function shouldLinkMissingUser(User $user, OAuthUser $oauthUser): bool
     {
         $id = Str::upper($this->getId());
 
-        return env("OAUTH_{$id}_SHOULD_LINK_MISSING_USERS", false);
+        return (bool) env("OAUTH_{$id}_SHOULD_LINK_MISSING_USERS", false);
     }
 }

--- a/app/Extensions/Spatie/Fractalistic/Fractal.php
+++ b/app/Extensions/Spatie/Fractalistic/Fractal.php
@@ -44,4 +44,17 @@ class Fractal extends SpatieFractal
 
         return parent::createData();
     }
+
+    /**
+     * Perform the transformation to array.
+     *
+     * @return array<mixed>
+     *
+     * @throws InvalidTransformation
+     * @throws NoTransformerSpecified
+     */
+    public function toArray(): array
+    {
+        return parent::toArray() ?? [];
+    }
 }

--- a/app/Filament/Admin/Pages/Health.php
+++ b/app/Filament/Admin/Pages/Health.php
@@ -41,7 +41,7 @@ class Health extends Page
 
     public static function canAccess(): bool
     {
-        return user()?->can('view health');
+        return user()?->can('view health') ?? false;
     }
 
     protected function getActions(): array

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -91,7 +91,7 @@ class Settings extends Page implements HasSchemas
 
     public static function canAccess(): bool
     {
-        return user()?->can('view settings');
+        return user()?->can('view settings') ?? false;
     }
 
     public function getTitle(): string

--- a/app/Filament/Admin/Resources/Eggs/EggResource.php
+++ b/app/Filament/Admin/Resources/Eggs/EggResource.php
@@ -34,7 +34,11 @@ class EggResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return user()?->getCustomization(CustomizationKey::TopNavigation) ? false : trans('admin/dashboard.server');
+        if (user()?->getCustomization(CustomizationKey::TopNavigation)) {
+            return null;
+        }
+
+        return trans('admin/dashboard.server');
     }
 
     public static function getNavigationLabel(): string

--- a/app/Filament/Admin/Resources/Nodes/NodeResource.php
+++ b/app/Filament/Admin/Resources/Nodes/NodeResource.php
@@ -46,7 +46,11 @@ class NodeResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return user()?->getCustomization(CustomizationKey::TopNavigation) ? false : trans('admin/dashboard.server');
+        if (user()?->getCustomization(CustomizationKey::TopNavigation)) {
+            return null;
+        }
+
+        return trans('admin/dashboard.server');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
@@ -305,7 +305,7 @@ class CreateServer extends CreateRecord
                         ->createOptionUsing(function (array $data, Get $get, AssignmentService $assignmentService): int {
                             return collect(
                                 $assignmentService->handle(Node::find($get('node_id')), $data)
-                            )->first();
+                            )->firstOrFail();
                         }),
                     Repeater::make('allocation_additional')
                         ->label(trans('admin/server.additional_allocations'))

--- a/app/Filament/Admin/Resources/Servers/ServerResource.php
+++ b/app/Filament/Admin/Resources/Servers/ServerResource.php
@@ -50,7 +50,11 @@ class ServerResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return user()?->getCustomization(CustomizationKey::TopNavigation) ? false : trans('admin/dashboard.server');
+        if (user()?->getCustomization(CustomizationKey::TopNavigation)) {
+            return null;
+        }
+
+        return trans('admin/dashboard.server');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Admin/Resources/Users/UserResource.php
+++ b/app/Filament/Admin/Resources/Users/UserResource.php
@@ -91,7 +91,11 @@ class UserResource extends Resource
 
     public static function getNavigationGroup(): ?string
     {
-        return user()?->getCustomization(CustomizationKey::TopNavigation) ? false : trans('admin/dashboard.user');
+        if (user()?->getCustomization(CustomizationKey::TopNavigation)) {
+            return null;
+        }
+
+        return trans('admin/dashboard.user');
     }
 
     public static function getNavigationBadge(): ?string

--- a/app/Filament/Components/Tables/Columns/Concerns/HasProgress.php
+++ b/app/Filament/Components/Tables/Columns/Concerns/HasProgress.php
@@ -3,7 +3,6 @@
 namespace App\Filament\Components\Tables\Columns\Concerns;
 
 use Closure;
-use Filament\Support\Colors\Color;
 
 /**
  * Trait extracted for progress-related shared functionality between columns.
@@ -17,19 +16,19 @@ trait HasProgress
     protected float|Closure|null $dangerThresholdPercent = null;
 
     /**
-     * @var string|array<int|string,string>|Closure|Color|null
+     * @var string|array<int|string,int|string>|Closure|null
      */
-    protected string|array|Closure|Color|null $dangerColor = null;
+    protected string|array|Closure|null $dangerColor = null;
 
     /**
-     * @var string|array<int|string,string>|Closure|Color|null
+     * @var string|array<int|string,int|string>|Closure|null
      */
-    protected string|array|Closure|Color|null $warningColor = null;
+    protected string|array|Closure|null $warningColor = null;
 
     /**
-     * @var string|array<int|string,string>|Closure|Color|null
+     * @var string|array<int|string,int|string>|Closure|null
      */
-    protected string|array|Closure|Color|null $color = null;
+    protected string|array|Closure|null $color = null;
 
     public function warningThresholdPercent(float|Closure $value): static
     {
@@ -56,9 +55,9 @@ trait HasProgress
     }
 
     /**
-     * @param  string|array<int|string,string>|Closure|Color  $color
+     * @param  string|array<int|string,int|string>|Closure  $color
      */
-    public function dangerColor(string|array|Closure|Color $color): static
+    public function dangerColor(string|array|Closure $color): static
     {
         $this->dangerColor = $color;
 
@@ -66,17 +65,17 @@ trait HasProgress
     }
 
     /**
-     * @return string|array<int|string,string>|Color|null
+     * @return string|array<int|string,int|string>|null
      */
-    public function getDangerColor(): string|array|Color|null
+    public function getDangerColor(): string|array|null
     {
         return $this->evaluate($this->dangerColor);
     }
 
     /**
-     * @param  string|array<int|string,string>|Closure|Color  $color
+     * @param  string|array<int|string,int|string>|Closure  $color
      */
-    public function warningColor(string|array|Closure|Color $color): static
+    public function warningColor(string|array|Closure $color): static
     {
         $this->warningColor = $color;
 
@@ -84,17 +83,17 @@ trait HasProgress
     }
 
     /**
-     * @return string|array<int|string,string>|Color|null
+     * @return string|array<int|string,int|string>|null
      */
-    public function getWarningColor(): string|array|Color|null
+    public function getWarningColor(): string|array|null
     {
         return $this->evaluate($this->warningColor);
     }
 
     /**
-     * @param  string|array<int|string,string>|Closure|Color  $color
+     * @param  string|array<int|string,int|string>|Closure  $color
      */
-    public function color(string|array|Closure|Color $color): static
+    public function color(string|array|Closure $color): static
     {
         $this->color = $color;
 
@@ -102,9 +101,9 @@ trait HasProgress
     }
 
     /**
-     * @return string|array<int|string,string>|Color|null
+     * @return string|array<int|string,int|string>|null
      */
-    public function getColor(): string|array|Color|null
+    public function getColor(): string|array|null
     {
         return $this->evaluate($this->color);
     }
@@ -112,9 +111,9 @@ trait HasProgress
     /**
      * Resolve a progress color for a given status string ('danger','warning','success').
      *
-     * @return string|array<int|string,string>|Color
+     * @return string|array<int|string,int|string>
      */
-    public function getProgressColorForStatus(string $status): string|array|Color
+    public function getProgressColorForStatus(string $status): string|array
     {
         $color = match ($status) {
             'danger' => $this->getDangerColor(),

--- a/app/Filament/Components/Tables/Columns/ProgressBarColumn.php
+++ b/app/Filament/Components/Tables/Columns/ProgressBarColumn.php
@@ -104,7 +104,7 @@ class ProgressBarColumn extends Column
     }
 
     /**
-     * @return string|array<int|string,string>
+     * @return string|array<int|string,int|string>
      */
     public function getProgressColor(): string|array
     {

--- a/app/Http/Controllers/Api/Remote/SftpAuthenticationController.php
+++ b/app/Http/Controllers/Api/Remote/SftpAuthenticationController.php
@@ -122,7 +122,7 @@ class SftpAuthenticationController extends Controller
     /**
      * Rejects the request and increments the login attempts.
      */
-    protected function reject(Request $request, bool $increment = true): void
+    protected function reject(Request $request, bool $increment = true): never
     {
         if ($increment) {
             $this->incrementLoginAttempts($request);

--- a/app/Http/Requests/Api/Application/ApplicationApiRequest.php
+++ b/app/Http/Requests/Api/Application/ApplicationApiRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\Application;
 use App\Exceptions\PanelException;
 use App\Models\ApiKey;
 use App\Services\Acl\Api\AdminAcl;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Foundation\Http\FormRequest;
 use Illuminate\Validation\Validator;
@@ -53,7 +54,7 @@ abstract class ApplicationApiRequest extends FormRequest
         return AdminAcl::check($token, $this->resource, $this->permission);
     }
 
-    /** @return array<string, string|string[]> */
+    /** @return array<string, string|array<string|\Stringable|ValidationRule>> */
     public function rules(): array
     {
         return [];

--- a/app/Http/Requests/Api/Application/DatabaseHosts/StoreDatabaseHostRequest.php
+++ b/app/Http/Requests/Api/Application/DatabaseHosts/StoreDatabaseHostRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\Application\DatabaseHosts;
 use App\Http\Requests\Api\Application\ApplicationApiRequest;
 use App\Models\DatabaseHost;
 use App\Services\Acl\Api\AdminAcl;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 class StoreDatabaseHostRequest extends ApplicationApiRequest
 {
@@ -13,8 +14,8 @@ class StoreDatabaseHostRequest extends ApplicationApiRequest
     protected int $permission = AdminAcl::WRITE;
 
     /**
-     * @param  array<string, string|string[]>|null  $rules
-     * @return array<string, string|string[]>
+     * @param  array<string, string|array<string|\Stringable|ValidationRule>>|null  $rules
+     * @return array<string, string|array<string|\Stringable|ValidationRule>>
      */
     public function rules(?array $rules = null): array
     {

--- a/app/Http/Requests/Api/Application/DatabaseHosts/UpdateDatabaseHostRequest.php
+++ b/app/Http/Requests/Api/Application/DatabaseHosts/UpdateDatabaseHostRequest.php
@@ -3,10 +3,11 @@
 namespace App\Http\Requests\Api\Application\DatabaseHosts;
 
 use App\Models\DatabaseHost;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 class UpdateDatabaseHostRequest extends StoreDatabaseHostRequest
 {
-    /** @return array<array-key, string|string[]> */
+    /** @return array<string, string|array<string|\Stringable|ValidationRule>> */
     public function rules(?array $rules = null): array
     {
         /** @var DatabaseHost $databaseHost */

--- a/app/Http/Requests/Api/Application/Mounts/UpdateMountRequest.php
+++ b/app/Http/Requests/Api/Application/Mounts/UpdateMountRequest.php
@@ -3,12 +3,13 @@
 namespace App\Http\Requests\Api\Application\Mounts;
 
 use App\Models\Mount;
+use Illuminate\Contracts\Validation\ValidationRule;
 
 class UpdateMountRequest extends StoreMountRequest
 {
     /**
-     * @param  array<string, string|string[]>|null  $rules
-     * @return array<string, string|string[]>
+     * @param  array<string, string|array<string|\Stringable|ValidationRule>>|null  $rules
+     * @return array<string, string|array<string|\Stringable|ValidationRule>>
      */
     public function rules(?array $rules = null): array
     {

--- a/app/Http/Requests/Api/Client/Account/StoreSSHKeyRequest.php
+++ b/app/Http/Requests/Api/Client/Account/StoreSSHKeyRequest.php
@@ -5,6 +5,7 @@ namespace App\Http\Requests\Api\Client\Account;
 use App\Http\Requests\Api\Client\ClientApiRequest;
 use App\Models\UserSSHKey;
 use Exception;
+use Illuminate\Contracts\Validation\ValidationRule;
 use Illuminate\Validation\Validator;
 use phpseclib3\Crypt\Common\PublicKey;
 use phpseclib3\Crypt\DSA;
@@ -16,7 +17,7 @@ class StoreSSHKeyRequest extends ClientApiRequest
 {
     protected ?PublicKey $key;
 
-    /** @return array<string, string|string[]> */
+    /** @return array<string, string|array<string|\Stringable|ValidationRule>> */
     public function rules(): array
     {
         return [

--- a/app/Livewire/AlertBanner.php
+++ b/app/Livewire/AlertBanner.php
@@ -10,6 +10,7 @@ use Filament\Notifications\Concerns\HasStatus;
 use Filament\Notifications\Concerns\HasTitle;
 use Filament\Support\Components\ViewComponent;
 use Illuminate\Contracts\Support\Arrayable;
+use Illuminate\Contracts\Support\Htmlable;
 use Livewire\Livewire;
 
 final class AlertBanner extends ViewComponent implements Arrayable
@@ -40,7 +41,7 @@ final class AlertBanner extends ViewComponent implements Arrayable
     }
 
     /**
-     * @return array{id: string, title: ?string, body: ?string, status: ?string, icon: ?string, closeable: bool}
+     * @return array{id: string, title: ?string, body: ?string, status: ?string, icon: string|\BackedEnum|Htmlable|null, closeable: bool}
      */
     public function toArray(): array
     {
@@ -55,7 +56,7 @@ final class AlertBanner extends ViewComponent implements Arrayable
     }
 
     /**
-     * @param  array{id: string, title: ?string, body: ?string, status: ?string, icon: ?string, closeable: bool}  $data
+     * @param  array{id: string, title: ?string, body: ?string, status: ?string, icon: string|\BackedEnum|Htmlable|null, closeable: bool}  $data
      */
     public static function fromArray(array $data): AlertBanner
     {

--- a/app/Livewire/AlertBannerCollection.php
+++ b/app/Livewire/AlertBannerCollection.php
@@ -3,13 +3,15 @@
 namespace App\Livewire;
 
 use Filament\Notifications\Collection;
+use Illuminate\Contracts\Support\Htmlable;
 
 class AlertBannerCollection extends Collection
 {
     public static function fromLivewire($value): static
     {
-        return (new static($value))->transform(
-            fn (array $alertBanner): AlertBanner => AlertBanner::fromArray($alertBanner),
-        );
+        return (new static($value))->transform(function (array $alertBanner): AlertBanner {
+            /** @var array{id: string, title: ?string, body: ?string, status: ?string, icon: string|\BackedEnum|Htmlable|null, closeable: bool} $alertBanner */
+            return AlertBanner::fromArray($alertBanner);
+        });
     }
 }

--- a/app/Models/EggVariable.php
+++ b/app/Models/EggVariable.php
@@ -85,7 +85,7 @@ class EggVariable extends Model implements Validatable
     /**
      * Implement language verification by overriding Eloquence's gather rules function.
      *
-     * @return array<string|string[]>
+     * @return array<string, string[]>
      */
     public static function getRules(): array
     {

--- a/app/Models/File.php
+++ b/app/Models/File.php
@@ -114,7 +114,7 @@ class File extends Model
 
     public function isImage(): bool
     {
-        return preg_match('/^image\/(?!svg\+xml)/', $this->mime_type);
+        return preg_match('/^image\/(?!svg\+xml)/', $this->mime_type) === 1;
     }
 
     public function getIcon(): BackedEnum

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -276,10 +276,12 @@ class Node extends Model implements Validatable
 
     /**
      * Returns the configuration in JSON format.
+     *
+     * @throws \JsonException
      */
     public function getJsonConfiguration(bool $pretty = false): string
     {
-        return json_encode($this->getConfiguration(), JSON_THROW_ON_ERROR | ($pretty ? JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT : JSON_UNESCAPED_SLASHES));
+        return json_encode($this->getConfiguration(), JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | ($pretty ? JSON_PRETTY_PRINT : 0));
     }
 
     public function isUnderMaintenance(): bool

--- a/app/Models/Node.php
+++ b/app/Models/Node.php
@@ -224,8 +224,8 @@ class Node extends Model implements Validatable
      *
      * @return array{
      *     debug: bool,
-     *     uuid: string,
-     *     token_id: string,
+     *     uuid: string|null,
+     *     token_id: string|null,
      *     token: string,
      *     api: array{
      *         host: string,
@@ -234,7 +234,7 @@ class Node extends Model implements Validatable
      *         upload_limit: int
      *     },
      *     system: array{data: string, sftp: array{bind_port: int}},
-     *     allowed_mounts: string[],
+     *     allowed_mounts: array<mixed>,
      *     remote: string,
      * }
      */
@@ -262,7 +262,7 @@ class Node extends Model implements Validatable
                 ],
             ],
             'allowed_mounts' => $this->mounts->pluck('source')->toArray(),
-            'remote' => config('app.url'),
+            'remote' => (string) config('app.url'),
         ];
     }
 
@@ -279,7 +279,7 @@ class Node extends Model implements Validatable
      */
     public function getJsonConfiguration(bool $pretty = false): string
     {
-        return json_encode($this->getConfiguration(), $pretty ? JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT : JSON_UNESCAPED_SLASHES);
+        return json_encode($this->getConfiguration(), JSON_THROW_ON_ERROR | ($pretty ? JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT : JSON_UNESCAPED_SLASHES));
     }
 
     public function isUnderMaintenance(): bool

--- a/app/Models/WebhookConfiguration.php
+++ b/app/Models/WebhookConfiguration.php
@@ -428,7 +428,7 @@ class WebhookConfiguration extends Model
                 return data_get($replacement, $trimmed, $trimmed);
             },
             $subject
-        );
+        ) ?? $subject;
     }
 
     /** @param array<mixed, mixed> $eventData */

--- a/app/Services/Activity/ActivityLogService.php
+++ b/app/Services/Activity/ActivityLogService.php
@@ -233,17 +233,19 @@ class ActivityLogService
     {
         Assert::notNull($this->activity);
 
-        $response = $this->connection->transaction(function () {
-            $this->activity->save();
+        $activity = $this->activity;
+
+        $response = $this->connection->transaction(function () use ($activity) {
+            $activity->save();
 
             foreach ($this->subjects as $subject) {
-                $this->activity->subjects()->forceCreate([
+                $activity->subjects()->forceCreate([
                     'subject_id' => $subject->getKey(),
                     'subject_type' => $subject->getMorphClass(),
                 ]);
             }
 
-            return $this->activity;
+            return $activity;
         });
 
         Event::dispatch(new ActivityLogged($response));

--- a/app/Services/Eggs/EggConfigurationService.php
+++ b/app/Services/Eggs/EggConfigurationService.php
@@ -20,14 +20,7 @@ class EggConfigurationService
      * @return array{
      *     startup: array{done: string[], user_interaction: string[], strip_ansi: bool},
      *     stop: array{type: string, value: string},
-     *     configs: list<array{
-     *         file: string,
-     *         replace: list<array{
-     *             match: string,
-     *             if_value?: string,
-     *             replace_with: string
-     *         }>
-     *     }>
+     *     configs: list<array<string, mixed>>
      * }
      */
     public function handle(Server $server): array
@@ -89,7 +82,7 @@ class EggConfigurationService
 
     /**
      * @param  array<string, mixed>  $configs
-     * @return array<int, array<string, mixed>>
+     * @return list<array<string, mixed>>
      */
     protected function replacePlaceholders(Server $server, object|array $configs): array
     {

--- a/app/Services/Eggs/Sharing/EggExporterService.php
+++ b/app/Services/Eggs/Sharing/EggExporterService.php
@@ -57,7 +57,7 @@ class EggExporterService
         ];
 
         return match ($format) {
-            EggFormat::JSON => json_encode($struct, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
+            EggFormat::JSON => json_encode($struct, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES),
             EggFormat::YAML => Yaml::dump($this->yamlExport($struct), 10, 2, Yaml::DUMP_MULTI_LINE_LITERAL_BLOCK | Yaml::DUMP_OBJECT_AS_MAP),
         };
     }

--- a/app/Services/Schedules/Sharing/ScheduleExporterService.php
+++ b/app/Services/Schedules/Sharing/ScheduleExporterService.php
@@ -34,6 +34,6 @@ class ScheduleExporterService
             }),
         ];
 
-        return json_encode($data, JSON_PRETTY_PRINT);
+        return json_encode($data, JSON_THROW_ON_ERROR | JSON_PRETTY_PRINT);
     }
 }

--- a/app/Services/Servers/EnvironmentService.php
+++ b/app/Services/Servers/EnvironmentService.php
@@ -7,7 +7,7 @@ use App\Models\Server;
 
 class EnvironmentService
 {
-    /** @var array<array-key, callable> */
+    /** @var array<string, callable> */
     private array $additional = [];
 
     /**
@@ -21,7 +21,7 @@ class EnvironmentService
     /**
      * Return the dynamically added additional keys.
      *
-     * @return array<array-key, callable>
+     * @return array<string, callable>
      */
     public function getEnvironmentKeys(): array
     {
@@ -32,7 +32,7 @@ class EnvironmentService
      * Take all the environment variables configured for this server and return
      * them in an easy to process format.
      *
-     * @return array<array-key, mixed>
+     * @return array<string, mixed>
      */
     public function handle(Server $server): array
     {
@@ -58,7 +58,7 @@ class EnvironmentService
     /**
      * Return a mapping of Panel default environment variables.
      *
-     * @return array<array-key, string>
+     * @return array<string, string>
      */
     private function getEnvironmentMappings(): array
     {

--- a/app/Services/Servers/GetUserPermissionsService.php
+++ b/app/Services/Servers/GetUserPermissionsService.php
@@ -37,7 +37,7 @@ class GetUserPermissionsService
 
         /** @var Subuser|null $subuser */
         $subuser = $server->subusers()->where('user_id', $user->id)->first();
-        $subuserPermissions = $subuser !== null ? $subuser->permissions : [];
+        $subuserPermissions = $subuser !== null ? ($subuser->permissions ?? []) : [];
 
         if ($isAdmin) {
             return array_unique(array_merge(

--- a/app/Services/Servers/ServerConfigurationStructureService.php
+++ b/app/Services/Servers/ServerConfigurationStructureService.php
@@ -40,7 +40,7 @@ class ServerConfigurationStructureService
      * @return array{
      *     id: int,
      *     uuid: string,
-     *     meta: array{name: string, description: string},
+     *     meta: array{name: string, description: string|null},
      *     suspended: bool,
      *     environment: array<string, mixed>,
      *     invocation: string,
@@ -60,9 +60,9 @@ class ServerConfigurationStructureService
      *         default: array{ip: string, port: int},
      *         mappings: array<string, array<int>>,
      *     },
-     *     egg: array{id: string, file_denylist: string[], features: string[][]},
-     *     labels?: string[],
-     *     mounts: array{source: string, target: string, read_only: bool},
+     *     egg: array{id: string|null, file_denylist: string[]|null, features: string[][]},
+     *     labels?: array<mixed>,
+     *     mounts?: array<mixed>,
      * }
      *
      * @todo convert to API Resource

--- a/app/Services/Servers/StartupModificationService.php
+++ b/app/Services/Servers/StartupModificationService.php
@@ -59,7 +59,7 @@ class StartupModificationService
             //
             // TODO: this seems like a red-flag for the code powering the relationship
             //  that should be looked into more.
-            return $server->fresh();
+            return $server->fresh() ?? $server;
         });
     }
 

--- a/app/Transformers/Api/Client/BaseClientTransformer.php
+++ b/app/Transformers/Api/Client/BaseClientTransformer.php
@@ -14,7 +14,11 @@ abstract class BaseClientTransformer extends BaseApplicationTransformer
      */
     public function getUser(): User
     {
-        return $this->request->user();
+        $user = $this->request->user();
+
+        Assert::isInstanceOf($user, User::class);
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Fixes every return.type error PHPStan reports at level 8, mostly nullability handling and docblocks that didn't match reality. No intended behavior changes, full test suite passes.