### PR TITLE
Add DB_SCHEMA support for PostgreSQL connections

### DIFF
--- a/app/Console/Commands/Environment/DatabaseSettingsCommand.php
+++ b/app/Console/Commands/Environment/DatabaseSettingsCommand.php
@@ -24,6 +24,7 @@ class DatabaseSettingsCommand extends Command
     protected $signature = 'p:environment:database
                             {--driver= : The database driver backend to use.}
                             {--database= : The database to use.}
+                            {--schema= : The schema to use for the PostgreSQL database.}
                             {--host= : The connection address for the MySQL/ MariaDB/ PostgreSQL server.}
                             {--port= : The connection port for the MySQL/ MariaDB/ PostgreSQL server.}
                             {--username= : Username to use when connecting to the MySQL/ MariaDB/ PostgreSQL server.}
@@ -196,6 +197,11 @@ class DatabaseSettingsCommand extends Command
                 config('database.connections.pgsql.database', 'panel')
             );
 
+            $this->variables['DB_SCHEMA'] = $this->option('schema') ?? $this->ask(
+                'Database Schema',
+                config('database.connections.pgsql.search_path', 'public')
+            );
+
             $this->output->note(trans('commands.database_settings.DB_USERNAME_note'));
             $this->variables['DB_USERNAME'] = $this->option('username') ?? $this->ask(
                 'Database Username',
@@ -224,7 +230,7 @@ class DatabaseSettingsCommand extends Command
                     'charset' => 'utf8',
                     'prefix' => '',
                     'prefix_indexes' => true,
-                    'search_path' => 'public',
+                    'search_path' => $this->variables['DB_SCHEMA'],
                     'sslmode' => 'prefer',
                 ]);
 

--- a/config/database.php
+++ b/config/database.php
@@ -101,7 +101,7 @@ return [
             'charset' => env('DB_CHARSET', 'utf8'),
             'prefix' => '',
             'prefix_indexes' => true,
-            'search_path' => 'public',
+            'search_path' => env('DB_SCHEMA', 'public'),
             'sslmode' => 'prefer',
         ],
 


### PR DESCRIPTION
## Summary

This PR adds support for configuring the PostgreSQL schema/search path through an environment variable.

Currently the PostgreSQL connection config uses a hardcoded `public` search path. This makes it difficult to run the panel in environments where a dedicated PostgreSQL schema is preferred instead of using the default `public` schema.

## Changes

- Added `DB_SCHEMA` environment variable support for PostgreSQL connections
- Kept `public` as the default value to preserve current behavior
- No breaking changes for existing installations

## Example

```env
DB_CONNECTION=pgsql
DB_SCHEMA=pelican