### PR TITLE
Add interface function to auto fill plugin settings form

### DIFF
--- a/app/Contracts/Plugins/HasPluginSettings.php
+++ b/app/Contracts/Plugins/HasPluginSettings.php
@@ -7,6 +7,11 @@ use Filament\Schemas\Components\Component;
 interface HasPluginSettings
 {
     /**
+     * @return array<string, mixed>
+     */
+    public function getSettingsFormData(): array;
+
+    /**
      * @return Component[]
      */
     public function getSettingsForm(): array;

--- a/app/Filament/Admin/Resources/Plugins/PluginResource.php
+++ b/app/Filament/Admin/Resources/Plugins/PluginResource.php
@@ -113,6 +113,7 @@ class PluginResource extends Resource
                     ->color('primary')
                     ->visible(fn (Plugin $plugin) => $plugin->status === PluginStatus::Enabled && $plugin->hasSettings())
                     ->schema(fn (Plugin $plugin) => $plugin->getSettingsForm())
+                    ->fillForm(fn (Plugin $plugin) => $plugin->getSettingsFormData())
                     ->action(fn (array $data, Plugin $plugin) => $plugin->saveSettings($data))
                     ->slideOver(),
                 ActionGroup::make([

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -335,6 +335,21 @@ class Plugin extends Model implements HasPluginSettings
         return false;
     }
 
+    /** @return array<string, mixed> */
+    public function getSettingsFormData(): array
+    {
+        try {
+            $pluginObject = new ($this->fullClass());
+
+            if ($pluginObject instanceof HasPluginSettings) {
+                return $pluginObject->getSettingsFormData();
+            }
+        } catch (Exception) {
+        }
+
+        return [];
+    }
+
     /** @return Component[] */
     public function getSettingsForm(): array
     {


### PR DESCRIPTION
Adds `getSettingsFormData` to the `HasPluginSettings` interface (_breaking change for plugins that implement this interface_) so the settings form can be automatically filled with data.