### PR TITLE
Add per-user server settings; including for backup notifications

### DIFF
--- a/app/Enums/ServerUserSettingKey.php
+++ b/app/Enums/ServerUserSettingKey.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Enums;
+
+enum ServerUserSettingKey: string
+{
+    case BackupNotifications = 'backup_notifications';
+
+    /**
+     * The default value for users without an explicit setting. Server owners
+     * may receive different defaults, see User::getServerSetting().
+     */
+    public function getDefaultValue(): bool
+    {
+        return match ($this) {
+            self::BackupNotifications => false,
+        };
+    }
+
+    /** @return array<string, bool> */
+    public static function getDefaultSettings(): array
+    {
+        $default = [];
+
+        foreach (self::cases() as $key) {
+            $default[$key->value] = $key->getDefaultValue();
+        }
+
+        return $default;
+    }
+}

--- a/app/Enums/ServerUserSettingKey.php
+++ b/app/Enums/ServerUserSettingKey.php
@@ -7,8 +7,7 @@ enum ServerUserSettingKey: string
     case BackupNotifications = 'backup_notifications';
 
     /**
-     * The default value for users without an explicit setting. Server owners
-     * may receive different defaults, see User::getServerSetting().
+     * The default value for users without an explicit setting.
      */
     public function getDefaultValue(): bool
     {

--- a/app/Enums/ServerUserSettingKey.php
+++ b/app/Enums/ServerUserSettingKey.php
@@ -4,7 +4,8 @@ namespace App\Enums;
 
 enum ServerUserSettingKey: string
 {
-    case BackupNotifications = 'backup_notifications';
+    case ManualBackupNotifications = 'manual_backup_notifications';
+    case ScheduledBackupNotifications = 'scheduled_backup_notifications';
 
     /**
      * The default value for users without an explicit setting.
@@ -12,7 +13,7 @@ enum ServerUserSettingKey: string
     public function getDefaultValue(): bool
     {
         return match ($this) {
-            self::BackupNotifications => false,
+            self::ManualBackupNotifications, self::ScheduledBackupNotifications => false,
         };
     }
 

--- a/app/Extensions/Tasks/Schemas/CreateBackupSchema.php
+++ b/app/Extensions/Tasks/Schemas/CreateBackupSchema.php
@@ -17,7 +17,7 @@ final class CreateBackupSchema extends TaskSchema
 
     public function runTask(Task $task): void
     {
-        $this->initiateService->setIgnoredFiles(explode(PHP_EOL, $task->payload))->handle($task->server, null, true);
+        $this->initiateService->setIsScheduled(true)->setIgnoredFiles(explode(PHP_EOL, $task->payload))->handle($task->server, null, true);
     }
 
     public function canCreate(Schedule $schedule): bool

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -689,16 +689,6 @@ class Settings extends Page implements HasSchemas
                         ->formatStateUsing(fn ($state): bool => (bool) $state)
                         ->afterStateUpdated(fn ($state, Set $set) => $set('PANEL_SEND_REINSTALL_NOTIFICATION', (bool) $state))
                         ->default(env('PANEL_SEND_REINSTALL_NOTIFICATION', config('panel.email.send_reinstall_notification'))),
-                    Toggle::make('PANEL_SEND_BACKUP_COMPLETED_NOTIFICATION')
-                        ->label(trans('admin/setting.misc.mail_notifications.backup_completed'))
-                        ->onIcon(TablerIcon::Check)
-                        ->offIcon(TablerIcon::X)
-                        ->onColor('success')
-                        ->offColor('danger')
-                        ->live()
-                        ->formatStateUsing(fn ($state): bool => (bool) $state)
-                        ->afterStateUpdated(fn ($state, Set $set) => $set('PANEL_SEND_BACKUP_COMPLETED_NOTIFICATION', (bool) $state))
-                        ->default(env('PANEL_SEND_BACKUP_COMPLETED_NOTIFICATION', config('panel.email.send_backup_completed_notification'))),
                 ]),
             Section::make(trans('admin/setting.misc.connections.title'))
                 ->description(trans('admin/setting.misc.connections.helper'))

--- a/app/Filament/Server/Pages/Settings.php
+++ b/app/Filament/Server/Pages/Settings.php
@@ -259,11 +259,16 @@ class Settings extends ServerFormPage
                 Section::make(trans('server/setting.notifications.title'))
                     ->columnSpanFull()
                     ->schema([
-                        Toggle::make('backup_notifications')
-                            ->label(trans('server/setting.notifications.backup.label'))
-                            ->helperText(trans('server/setting.notifications.backup.helper'))
+                        Toggle::make(ServerUserSettingKey::ManualBackupNotifications->value)
+                            ->label(trans('server/setting.notifications.backup_manual.label'))
+                            ->helperText(trans('server/setting.notifications.backup_manual.helper'))
                             ->live()
-                            ->afterStateUpdated(fn ($state, Server $server) => $this->updateBackupNotifications((bool) $state, $server)),
+                            ->afterStateUpdated(fn ($state, Server $server) => $this->updateNotificationSetting(ServerUserSettingKey::ManualBackupNotifications, (bool) $state, $server)),
+                        Toggle::make(ServerUserSettingKey::ScheduledBackupNotifications->value)
+                            ->label(trans('server/setting.notifications.backup_scheduled.label'))
+                            ->helperText(trans('server/setting.notifications.backup_scheduled.helper'))
+                            ->live()
+                            ->afterStateUpdated(fn ($state, Server $server) => $this->updateNotificationSetting(ServerUserSettingKey::ScheduledBackupNotifications, (bool) $state, $server)),
                     ]),
             ]);
     }
@@ -272,14 +277,16 @@ class Settings extends ServerFormPage
     {
         $data = $this->getRecord()->attributesToArray();
 
-        $data['backup_notifications'] = (bool) user()?->getServerSetting($this->getRecord(), ServerUserSettingKey::BackupNotifications);
+        foreach (ServerUserSettingKey::cases() as $key) {
+            $data[$key->value] = (bool) user()?->getServerSetting($this->getRecord(), $key);
+        }
 
         $this->form->fill($data);
     }
 
-    public function updateBackupNotifications(bool $state, Server $server): void
+    public function updateNotificationSetting(ServerUserSettingKey $key, bool $state, Server $server): void
     {
-        user()?->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, $state);
+        user()?->updateServerSetting($server, $key, $state);
 
         Notification::make()
             ->title(trans('server/setting.notifications.saved'))

--- a/app/Filament/Server/Pages/Settings.php
+++ b/app/Filament/Server/Pages/Settings.php
@@ -2,6 +2,7 @@
 
 namespace App\Filament\Server\Pages;
 
+use App\Enums\ServerUserSettingKey;
 use App\Enums\SubuserPermission;
 use App\Enums\TablerIcon;
 use App\Facades\Activity;
@@ -14,6 +15,7 @@ use Exception;
 use Filament\Actions\Action;
 use Filament\Forms\Components\Textarea;
 use Filament\Forms\Components\TextInput;
+use Filament\Forms\Components\Toggle;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Notifications\Notification;
 use Filament\Schemas\Components\Fieldset;
@@ -254,7 +256,35 @@ class Settings extends ServerFormPage
                         TextEntry::make('files_info')
                             ->label(trans('server/setting.reinstall.body2')),
                     ]),
+                Section::make(trans('server/setting.notifications.title'))
+                    ->columnSpanFull()
+                    ->schema([
+                        Toggle::make('backup_notifications')
+                            ->label(trans('server/setting.notifications.backup.label'))
+                            ->helperText(trans('server/setting.notifications.backup.helper'))
+                            ->live()
+                            ->afterStateUpdated(fn ($state, Server $server) => $this->updateBackupNotifications((bool) $state, $server)),
+                    ]),
             ]);
+    }
+
+    protected function fillForm(): void
+    {
+        $data = $this->getRecord()->attributesToArray();
+
+        $data['backup_notifications'] = (bool) user()?->getServerSetting($this->getRecord(), ServerUserSettingKey::BackupNotifications);
+
+        $this->form->fill($data);
+    }
+
+    public function updateBackupNotifications(bool $state, Server $server): void
+    {
+        user()?->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, $state);
+
+        Notification::make()
+            ->title(trans('server/setting.notifications.saved'))
+            ->success()
+            ->send();
     }
 
     public function updateName(string $name, Server $server): void

--- a/app/Filament/Server/Resources/Backups/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/Backups/Pages/ListBackups.php
@@ -32,13 +32,19 @@ class ListBackups extends ListRecords
                 ->label(trans('server/backup.notifications.action'))
                 ->icon(TablerIcon::Bell)
                 ->schema([
-                    Toggle::make('backup_notifications')
-                        ->label(trans('server/backup.notifications.toggle'))
-                        ->helperText(trans('server/backup.notifications.helper'))
-                        ->default(fn () => (bool) user()?->getServerSetting($server, ServerUserSettingKey::BackupNotifications)),
+                    Toggle::make(ServerUserSettingKey::ManualBackupNotifications->value)
+                        ->label(trans('server/backup.notifications.toggle_manual'))
+                        ->helperText(trans('server/backup.notifications.helper_manual'))
+                        ->default(fn () => (bool) user()?->getServerSetting($server, ServerUserSettingKey::ManualBackupNotifications)),
+                    Toggle::make(ServerUserSettingKey::ScheduledBackupNotifications->value)
+                        ->label(trans('server/backup.notifications.toggle_scheduled'))
+                        ->helperText(trans('server/backup.notifications.helper_scheduled'))
+                        ->default(fn () => (bool) user()?->getServerSetting($server, ServerUserSettingKey::ScheduledBackupNotifications)),
                 ])
                 ->action(function (array $data) use ($server) {
-                    user()?->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, (bool) $data['backup_notifications']);
+                    foreach (ServerUserSettingKey::cases() as $key) {
+                        user()?->updateServerSetting($server, $key, (bool) $data[$key->value]);
+                    }
 
                     Notification::make()
                         ->title(trans('server/backup.notifications.saved'))

--- a/app/Filament/Server/Resources/Backups/Pages/ListBackups.php
+++ b/app/Filament/Server/Resources/Backups/Pages/ListBackups.php
@@ -2,9 +2,16 @@
 
 namespace App\Filament\Server\Resources\Backups\Pages;
 
+use App\Enums\ServerUserSettingKey;
+use App\Enums\TablerIcon;
 use App\Filament\Server\Resources\Backups\BackupResource;
+use App\Models\Server;
 use App\Traits\Filament\CanCustomizeHeaderActions;
 use App\Traits\Filament\CanCustomizeHeaderWidgets;
+use Filament\Actions\Action;
+use Filament\Facades\Filament;
+use Filament\Forms\Components\Toggle;
+use Filament\Notifications\Notification;
 use Filament\Resources\Pages\ListRecords;
 
 class ListBackups extends ListRecords
@@ -13,6 +20,33 @@ class ListBackups extends ListRecords
     use CanCustomizeHeaderWidgets;
 
     protected static string $resource = BackupResource::class;
+
+    /** @return Action[] */
+    protected function getDefaultHeaderActions(): array
+    {
+        /** @var Server $server */
+        $server = Filament::getTenant();
+
+        return [
+            Action::make('notification_settings')
+                ->label(trans('server/backup.notifications.action'))
+                ->icon(TablerIcon::Bell)
+                ->schema([
+                    Toggle::make('backup_notifications')
+                        ->label(trans('server/backup.notifications.toggle'))
+                        ->helperText(trans('server/backup.notifications.helper'))
+                        ->default(fn () => (bool) user()?->getServerSetting($server, ServerUserSettingKey::BackupNotifications)),
+                ])
+                ->action(function (array $data) use ($server) {
+                    user()?->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, (bool) $data['backup_notifications']);
+
+                    Notification::make()
+                        ->title(trans('server/backup.notifications.saved'))
+                        ->success()
+                        ->send();
+                }),
+        ];
+    }
 
     public function getBreadcrumbs(): array
     {

--- a/app/Listeners/Server/BackupCompletedListener.php
+++ b/app/Listeners/Server/BackupCompletedListener.php
@@ -30,14 +30,12 @@ class BackupCompletedListener
             ->get()
             ->keyBy('user_id');
 
-        // Owners receive notifications unless they opt out, subusers only if they opt in.
-        $recipients = $candidates->filter(function (User $user) use ($server, $settings) {
+        // Users only receive notifications if they opted in.
+        $recipients = $candidates->filter(function (User $user) use ($settings) {
             $userSettings = $settings->get($user->id)->settings ?? [];
 
-            return (bool) ($userSettings[ServerUserSettingKey::BackupNotifications->value] ?? ($user->id === $server->owner_id));
+            return (bool) ($userSettings[ServerUserSettingKey::BackupNotifications->value] ?? ServerUserSettingKey::BackupNotifications->getDefaultValue());
         });
-
-        $sendEmail = config()->get('panel.email.send_backup_completed_notification', true);
 
         foreach ($recipients as $user) {
             $locale = $user->language ?? 'en';
@@ -55,9 +53,7 @@ class BackupCompletedListener
                 ])
                 ->sendToDatabase($user);
 
-            if ($sendEmail) {
-                $user->notify(new BackupCompletedNotification($event->backup));
-            }
+            $user->notify(new BackupCompletedNotification($event->backup));
         }
     }
 }

--- a/app/Listeners/Server/BackupCompletedListener.php
+++ b/app/Listeners/Server/BackupCompletedListener.php
@@ -2,8 +2,11 @@
 
 namespace App\Listeners\Server;
 
+use App\Enums\ServerUserSettingKey;
 use App\Events\Server\BackupCompleted;
 use App\Filament\Server\Resources\Backups\Pages\ListBackups;
+use App\Models\ServerUserSettings;
+use App\Models\User;
 use App\Notifications\BackupCompleted as BackupCompletedNotification;
 use Filament\Actions\Action;
 use Filament\Notifications\Notification;
@@ -12,26 +15,49 @@ class BackupCompletedListener
 {
     public function handle(BackupCompleted $event): void
     {
-        $event->backup->loadMissing('server');
-        $event->backup->server->loadMissing('user');
+        $event->backup->loadMissing(['server.user', 'server.subusers.user']);
 
-        $locale = $event->backup->server->user->language ?? 'en';
+        $server = $event->backup->server;
 
-        Notification::make()
-            ->status($event->backup->is_successful ? 'success' : 'danger')
-            ->title(trans('notifications.backup_' . ($event->backup->is_successful ? 'completed' : 'failed'), locale: $locale))
-            ->body(trans('notifications.backup_body', ['name' => $event->backup->name, 'server' => $event->backup->server->name], $locale))
-            ->actions([
-                Action::make('exclude_view')
-                    ->button()
-                    ->label(trans('notifications.view_backups', locale: $locale))
-                    ->markAsRead()
-                    ->url(fn () => ListBackups::getUrl(panel: 'server', tenant: $event->backup->server)),
-            ])
-            ->sendToDatabase($event->backup->server->user);
+        $candidates = collect([$server->user])
+            ->concat($server->subusers->map->user)
+            ->filter()
+            ->unique('id');
 
-        if (config()->get('panel.email.send_backup_completed_notification', true)) {
-            $event->backup->server->user->notify(new BackupCompletedNotification($event->backup));
+        $settings = ServerUserSettings::query()
+            ->where('server_id', $server->id)
+            ->whereIn('user_id', $candidates->pluck('id'))
+            ->get()
+            ->keyBy('user_id');
+
+        // Owners receive notifications unless they opt out, subusers only if they opt in.
+        $recipients = $candidates->filter(function (User $user) use ($server, $settings) {
+            $userSettings = $settings->get($user->id)->settings ?? [];
+
+            return (bool) ($userSettings[ServerUserSettingKey::BackupNotifications->value] ?? ($user->id === $server->owner_id));
+        });
+
+        $sendEmail = config()->get('panel.email.send_backup_completed_notification', true);
+
+        foreach ($recipients as $user) {
+            $locale = $user->language ?? 'en';
+
+            Notification::make()
+                ->status($event->backup->is_successful ? 'success' : 'danger')
+                ->title(trans('notifications.backup_' . ($event->backup->is_successful ? 'completed' : 'failed'), locale: $locale))
+                ->body(trans('notifications.backup_body', ['name' => $event->backup->name, 'server' => $server->name], $locale))
+                ->actions([
+                    Action::make('exclude_view')
+                        ->button()
+                        ->label(trans('notifications.view_backups', locale: $locale))
+                        ->markAsRead()
+                        ->url(fn () => ListBackups::getUrl(panel: 'server', tenant: $server)),
+                ])
+                ->sendToDatabase($user);
+
+            if ($sendEmail) {
+                $user->notify(new BackupCompletedNotification($event->backup));
+            }
         }
     }
 }

--- a/app/Listeners/Server/BackupCompletedListener.php
+++ b/app/Listeners/Server/BackupCompletedListener.php
@@ -30,11 +30,13 @@ class BackupCompletedListener
             ->get()
             ->keyBy('user_id');
 
-        // Users only receive notifications if they opted in.
-        $recipients = $candidates->filter(function (User $user) use ($settings) {
+        // Users only receive notifications if they opted in for this kind of backup.
+        $key = $event->backup->is_scheduled ? ServerUserSettingKey::ScheduledBackupNotifications : ServerUserSettingKey::ManualBackupNotifications;
+
+        $recipients = $candidates->filter(function (User $user) use ($settings, $key) {
             $userSettings = $settings->get($user->id)->settings ?? [];
 
-            return (bool) ($userSettings[ServerUserSettingKey::BackupNotifications->value] ?? ServerUserSettingKey::BackupNotifications->getDefaultValue());
+            return (bool) ($userSettings[$key->value] ?? $key->getDefaultValue());
         });
 
         foreach ($recipients as $user) {

--- a/app/Models/Backup.php
+++ b/app/Models/Backup.php
@@ -31,6 +31,7 @@ use Illuminate\Database\Query\Builder;
  * @property bool $is_successful
  * @property string|null $upload_id
  * @property bool $is_locked
+ * @property bool $is_scheduled
  * @property-read Server $server
  * @property-read BackupStatus $status
  *
@@ -69,6 +70,7 @@ class Backup extends Model implements Validatable
     protected $attributes = [
         'is_successful' => false,
         'is_locked' => false,
+        'is_scheduled' => false,
         'checksum' => null,
         'bytes' => 0,
         'upload_id' => null,
@@ -82,6 +84,7 @@ class Backup extends Model implements Validatable
         'uuid' => ['required', 'uuid'],
         'is_successful' => ['boolean'],
         'is_locked' => ['boolean'],
+        'is_scheduled' => ['boolean'],
         'name' => ['required', 'string'],
         'ignored_files' => ['array'],
         'backup_host_id' => ['required', 'integer', 'exists:backup_hosts,id'],
@@ -96,6 +99,7 @@ class Backup extends Model implements Validatable
             'id' => 'int',
             'is_successful' => 'bool',
             'is_locked' => 'bool',
+            'is_scheduled' => 'bool',
             'ignored_files' => 'array',
             'bytes' => 'int',
             'completed_at' => 'immutable_datetime',

--- a/app/Models/Server.php
+++ b/app/Models/Server.php
@@ -90,6 +90,8 @@ use Psr\Http\Message\ResponseInterface;
  * @property-read int|null $server_variables_count
  * @property-read Collection<int, Subuser> $subusers
  * @property-read int|null $subusers_count
+ * @property-read Collection<int, ServerUserSettings> $userSettings
+ * @property-read int|null $user_settings_count
  * @property-read ServerTransfer|null $transfer
  * @property-read User $user
  * @property-read Collection<int, EggVariable> $variables
@@ -269,6 +271,16 @@ class Server extends Model implements HasAvatar, Validatable
     public function subusers(): HasMany
     {
         return $this->hasMany(Subuser::class, 'server_id', 'id');
+    }
+
+    /**
+     * Gets the per-user settings associated with a server.
+     *
+     * @return HasMany<ServerUserSettings, $this>
+     */
+    public function userSettings(): HasMany
+    {
+        return $this->hasMany(ServerUserSettings::class);
     }
 
     /**

--- a/app/Models/ServerUserSettings.php
+++ b/app/Models/ServerUserSettings.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Models;
+
+use App\Contracts\Validatable;
+use App\Traits\HasValidation;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $user_id
+ * @property int $server_id
+ * @property array<string, string|int|bool>|null $settings
+ * @property Carbon|null $created_at
+ * @property Carbon|null $updated_at
+ * @property-read Server $server
+ * @property-read User $user
+ *
+ * @method static \Database\Factories\ServerUserSettingsFactory factory($count = null, $state = [])
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings newModelQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings newQuery()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings query()
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereCreatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereServerId($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereSettings($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereUpdatedAt($value)
+ * @method static \Illuminate\Database\Eloquent\Builder<static>|ServerUserSettings whereUserId($value)
+ */
+class ServerUserSettings extends Model implements Validatable
+{
+    use HasFactory;
+    use HasValidation;
+
+    /**
+     * The resource name for this model when it is transformed into an
+     * API representation using fractal.
+     */
+    public const RESOURCE_NAME = 'server_user_settings';
+
+    protected $table = 'server_user_settings';
+
+    /**
+     * Fields that are not mass assignable.
+     */
+    protected $guarded = ['id', 'created_at', 'updated_at'];
+
+    /** @var array<array-key, string[]> */
+    public static array $validationRules = [
+        'user_id' => ['required', 'numeric', 'exists:users,id'],
+        'server_id' => ['required', 'numeric', 'exists:servers,id'],
+        'settings' => ['nullable', 'array'],
+        'settings.backup_notifications' => ['boolean'],
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'user_id' => 'int',
+            'server_id' => 'int',
+            'settings' => 'array',
+        ];
+    }
+
+    /**
+     * Gets the server these settings are associated with.
+     */
+    public function server(): BelongsTo
+    {
+        return $this->belongsTo(Server::class);
+    }
+
+    /**
+     * Gets the user these settings are associated with.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/ServerUserSettings.php
+++ b/app/Models/ServerUserSettings.php
@@ -53,7 +53,8 @@ class ServerUserSettings extends Model implements Validatable
         'user_id' => ['required', 'numeric', 'exists:users,id'],
         'server_id' => ['required', 'numeric', 'exists:servers,id'],
         'settings' => ['nullable', 'array'],
-        'settings.backup_notifications' => ['boolean'],
+        'settings.manual_backup_notifications' => ['boolean'],
+        'settings.scheduled_backup_notifications' => ['boolean'],
     ];
 
     protected function casts(): array

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Contracts\Validatable;
 use App\Enums\CustomizationKey;
+use App\Enums\ServerUserSettingKey;
 use App\Enums\SubuserPermission;
 use App\Events\User\Deleting;
 use App\Exceptions\DisplayException;
@@ -86,6 +87,8 @@ use Spatie\Permission\Traits\HasRoles;
  * @property-read int|null $sub_servers_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, Subuser> $subusers
  * @property-read int|null $subusers_count
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, ServerUserSettings> $serverSettings
+ * @property-read int|null $server_settings_count
  * @property-read \Illuminate\Database\Eloquent\Collection<int, ApiKey> $tokens
  * @property-read int|null $tokens_count
  *
@@ -349,6 +352,33 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     public function subServers(): BelongsToMany
     {
         return $this->belongsToMany(Server::class, 'subusers');
+    }
+
+    /** @return HasMany<ServerUserSettings, $this> */
+    public function serverSettings(): HasMany
+    {
+        return $this->hasMany(ServerUserSettings::class);
+    }
+
+    public function getServerSetting(Server $server, ServerUserSettingKey $key): string|int|bool
+    {
+        $settings = $this->serverSettings()->where('server_id', $server->id)->first()->settings ?? [];
+
+        return $settings[$key->value] ?? match ($key) {
+            // Owners receive backup notifications unless they explicitly opt out.
+            ServerUserSettingKey::BackupNotifications => $this->id === $server->owner_id,
+        };
+    }
+
+    public function updateServerSetting(Server $server, ServerUserSettingKey $key, string|int|bool $value): void
+    {
+        $row = $this->serverSettings()->firstOrNew(['server_id' => $server->id]);
+
+        $settings = $row->settings ?? [];
+        $settings[$key->value] = $value;
+
+        $row->settings = array_intersect_key($settings, ServerUserSettingKey::getDefaultSettings());
+        $row->save();
     }
 
     /** @return ($key is null ? array<string, string|int|bool> : string|int|bool) */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -364,10 +364,7 @@ class User extends Model implements AuthenticatableContract, AuthorizableContrac
     {
         $settings = $this->serverSettings()->where('server_id', $server->id)->first()->settings ?? [];
 
-        return $settings[$key->value] ?? match ($key) {
-            // Owners receive backup notifications unless they explicitly opt out.
-            ServerUserSettingKey::BackupNotifications => $this->id === $server->owner_id,
-        };
+        return $settings[$key->value] ?? $key->getDefaultValue();
     }
 
     public function updateServerSetting(Server $server, ServerUserSettingKey $key, string|int|bool $value): void

--- a/app/Services/Backups/InitiateBackupService.php
+++ b/app/Services/Backups/InitiateBackupService.php
@@ -21,6 +21,8 @@ class InitiateBackupService
 
     private bool $isLocked = false;
 
+    private bool $isScheduled = false;
+
     /**
      * InitiateBackupService constructor.
      */
@@ -37,6 +39,16 @@ class InitiateBackupService
     public function setIsLocked(bool $isLocked): self
     {
         $this->isLocked = $isLocked;
+
+        return $this;
+    }
+
+    /**
+     * Set if the backup was initiated by a schedule rather than a user.
+     */
+    public function setIsScheduled(bool $isScheduled): self
+    {
+        $this->isScheduled = $isScheduled;
 
         return $this;
     }
@@ -125,6 +137,7 @@ class InitiateBackupService
                 'ignored_files' => array_values($this->ignoredFiles ?? []),
                 'backup_host_id' => $backupHost->id,
                 'is_locked' => $this->isLocked,
+                'is_scheduled' => $this->isScheduled,
             ]);
 
             $schema->createBackup($backup);

--- a/app/Transformers/Api/Client/BackupTransformer.php
+++ b/app/Transformers/Api/Client/BackupTransformer.php
@@ -20,6 +20,7 @@ class BackupTransformer extends BaseClientTransformer
             'uuid' => $backup->uuid,
             'is_successful' => $backup->is_successful,
             'is_locked' => $backup->is_locked,
+            'is_scheduled' => $backup->is_scheduled,
             'name' => $backup->name,
             'ignored_files' => $backup->ignored_files,
             'checksum' => $backup->checksum,

--- a/config/panel.php
+++ b/config/panel.php
@@ -55,8 +55,6 @@ return [
         'send_install_notification' => env('PANEL_SEND_INSTALL_NOTIFICATION', true),
         // Should an email be sent to a server owner whenever their server is reinstalled?
         'send_reinstall_notification' => env('PANEL_SEND_REINSTALL_NOTIFICATION', true),
-        // Should an email be sent to a server owner whenever a backup is completed?
-        'send_backup_completed_notification' => env('PANEL_SEND_BACKUP_COMPLETED_NOTIFICATION', true),
     ],
 
     'filament' => [

--- a/database/Factories/ServerUserSettingsFactory.php
+++ b/database/Factories/ServerUserSettingsFactory.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Enums\ServerUserSettingKey;
+use App\Models\ServerUserSettings;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+class ServerUserSettingsFactory extends Factory
+{
+    /**
+     * The name of the factory's corresponding model.
+     *
+     * @var string
+     */
+    protected $model = ServerUserSettings::class;
+
+    /**
+     * Define the model's default state.
+     */
+    public function definition(): array
+    {
+        return [
+            'settings' => [
+                ServerUserSettingKey::BackupNotifications->value => true,
+            ],
+        ];
+    }
+
+    /**
+     * Indicate the user has opted in to backup notifications.
+     */
+    public function optedIn(): static
+    {
+        return $this->state([
+            'settings' => [
+                ServerUserSettingKey::BackupNotifications->value => true,
+            ],
+        ]);
+    }
+
+    /**
+     * Indicate the user has opted out of backup notifications.
+     */
+    public function optedOut(): static
+    {
+        return $this->state([
+            'settings' => [
+                ServerUserSettingKey::BackupNotifications->value => false,
+            ],
+        ]);
+    }
+}

--- a/database/Factories/ServerUserSettingsFactory.php
+++ b/database/Factories/ServerUserSettingsFactory.php
@@ -22,31 +22,34 @@ class ServerUserSettingsFactory extends Factory
     {
         return [
             'settings' => [
-                ServerUserSettingKey::BackupNotifications->value => true,
+                ServerUserSettingKey::ManualBackupNotifications->value => true,
+                ServerUserSettingKey::ScheduledBackupNotifications->value => true,
             ],
         ];
     }
 
     /**
-     * Indicate the user has opted in to backup notifications.
+     * Indicate the user has opted in to all backup notifications.
      */
     public function optedIn(): static
     {
         return $this->state([
             'settings' => [
-                ServerUserSettingKey::BackupNotifications->value => true,
+                ServerUserSettingKey::ManualBackupNotifications->value => true,
+                ServerUserSettingKey::ScheduledBackupNotifications->value => true,
             ],
         ]);
     }
 
     /**
-     * Indicate the user has opted out of backup notifications.
+     * Indicate the user has opted out of all backup notifications.
      */
     public function optedOut(): static
     {
         return $this->state([
             'settings' => [
-                ServerUserSettingKey::BackupNotifications->value => false,
+                ServerUserSettingKey::ManualBackupNotifications->value => false,
+                ServerUserSettingKey::ScheduledBackupNotifications->value => false,
             ],
         ]);
     }

--- a/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
+++ b/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
@@ -1,0 +1,28 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('server_user_settings', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedInteger('user_id');
+            $table->unsignedInteger('server_id');
+            $table->json('settings')->nullable();
+            $table->timestamps();
+
+            $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
+            $table->foreign('server_id')->references('id')->on('servers')->cascadeOnDelete();
+            $table->unique(['user_id', 'server_id']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('server_user_settings');
+    }
+};

--- a/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
+++ b/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
@@ -34,7 +34,7 @@ return new class extends Migration
             DB::table('server_user_settings')->insert($servers->map(fn ($server) => [
                 'user_id' => $server->owner_id,
                 'server_id' => $server->id,
-                'settings' => json_encode(['backup_notifications' => true]),
+                'settings' => json_encode(['manual_backup_notifications' => true, 'scheduled_backup_notifications' => true]),
                 'created_at' => $now,
                 'updated_at' => $now,
             ])->all());

--- a/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
+++ b/database/migrations/2026_07_12_000000_create_server_user_settings_table.php
@@ -2,6 +2,7 @@
 
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
@@ -18,6 +19,25 @@ return new class extends Migration
             $table->foreign('user_id')->references('id')->on('users')->cascadeOnDelete();
             $table->foreign('server_id')->references('id')->on('servers')->cascadeOnDelete();
             $table->unique(['user_id', 'server_id']);
+        });
+
+        // Backup notifications now default off for everyone. Owners on existing
+        // installs previously always received them, so seed an opt-in row for each
+        // server's owner unless the panel-wide email switch was already disabled.
+        if (!filter_var(env('PANEL_SEND_BACKUP_COMPLETED_NOTIFICATION', true), FILTER_VALIDATE_BOOL)) {
+            return;
+        }
+
+        $now = now();
+
+        DB::table('servers')->select(['id', 'owner_id'])->orderBy('id')->chunkById(250, function ($servers) use ($now) {
+            DB::table('server_user_settings')->insert($servers->map(fn ($server) => [
+                'user_id' => $server->owner_id,
+                'server_id' => $server->id,
+                'settings' => json_encode(['backup_notifications' => true]),
+                'created_at' => $now,
+                'updated_at' => $now,
+            ])->all());
         });
     }
 

--- a/database/migrations/2026_07_17_000000_add_is_scheduled_to_backups_table.php
+++ b/database/migrations/2026_07_17_000000_add_is_scheduled_to_backups_table.php
@@ -1,0 +1,22 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('backups', function (Blueprint $table) {
+            $table->boolean('is_scheduled')->default(false)->after('is_locked');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('backups', function (Blueprint $table) {
+            $table->dropColumn('is_scheduled');
+        });
+    }
+};

--- a/lang/en/admin/setting.php
+++ b/lang/en/admin/setting.php
@@ -121,7 +121,6 @@ return [
             'removed_from_server' => 'Removed from Server',
             'server_installed' => 'Server Installed',
             'server_reinstalled' => 'Server Reinstalled',
-            'backup_completed' => 'Backup Completed',
         ],
         'connections' => [
             'title' => 'Connections',

--- a/lang/en/server/backup.php
+++ b/lang/en/server/backup.php
@@ -14,8 +14,10 @@ return [
     ],
     'notifications' => [
         'action' => 'Notification Settings',
-        'toggle' => 'Backup Notifications',
-        'helper' => 'Receive a notification and email when a backup for this server completes or fails.',
+        'toggle_manual' => 'Manual Backup Notifications',
+        'helper_manual' => 'Receive a notification and email when a manually created backup for this server completes or fails.',
+        'toggle_scheduled' => 'Scheduled Backup Notifications',
+        'helper_scheduled' => 'Receive a notification and email when a scheduled backup for this server completes or fails.',
         'saved' => 'Notification Settings Updated',
     ],
     'actions' => [

--- a/lang/en/server/backup.php
+++ b/lang/en/server/backup.php
@@ -12,6 +12,12 @@ return [
         'successful' => 'Successful',
         'failed' => 'Failed',
     ],
+    'notifications' => [
+        'action' => 'Notification Settings',
+        'toggle' => 'Backup Notifications',
+        'helper' => 'Receive a notification and email when a backup for this server completes or fails.',
+        'saved' => 'Notification Settings Updated',
+    ],
     'actions' => [
         'create' => [
             'title' => 'Create Backup',

--- a/lang/en/server/setting.php
+++ b/lang/en/server/setting.php
@@ -41,6 +41,14 @@ return [
             'password_body' => 'Your SFTP password is the same as the password you use to access this panel.',
         ],
     ],
+    'notifications' => [
+        'title' => 'Notifications',
+        'saved' => 'Notification Settings Updated',
+        'backup' => [
+            'label' => 'Backup Notifications',
+            'helper' => 'Receive a notification and email when a backup for this server completes or fails.',
+        ],
+    ],
     'reinstall' => [
         'title' => 'Reinstall Server',
         'body' => 'Reinstalling your server will stop it, and then re-run the installation script that initially set it up.',

--- a/lang/en/server/setting.php
+++ b/lang/en/server/setting.php
@@ -44,9 +44,13 @@ return [
     'notifications' => [
         'title' => 'Notifications',
         'saved' => 'Notification Settings Updated',
-        'backup' => [
-            'label' => 'Backup Notifications',
-            'helper' => 'Receive a notification and email when a backup for this server completes or fails.',
+        'backup_manual' => [
+            'label' => 'Manual Backup Notifications',
+            'helper' => 'Receive a notification and email when a manually created backup for this server completes or fails.',
+        ],
+        'backup_scheduled' => [
+            'label' => 'Scheduled Backup Notifications',
+            'helper' => 'Receive a notification and email when a scheduled backup for this server completes or fails.',
         ],
     ],
     'reinstall' => [

--- a/tests/Feature/BackupNotificationSettingsTest.php
+++ b/tests/Feature/BackupNotificationSettingsTest.php
@@ -13,12 +13,13 @@ use App\Notifications\BackupCompleted as BackupCompletedNotification;
 use Filament\Notifications\DatabaseNotification;
 use Illuminate\Support\Facades\Notification;
 
-function runBackupCompletedListener(Server $server): void
+function runBackupCompletedListener(Server $server, bool $scheduled = false): void
 {
     /** @var Backup $backup */
     $backup = Backup::factory()->create([
         'server_id' => $server->id,
         'backup_host_id' => BackupHost::factory()->create()->id,
+        'is_scheduled' => $scheduled,
     ]);
 
     (new BackupCompletedListener())->handle(new BackupCompleted($backup));
@@ -30,6 +31,7 @@ it('does not notify anyone by default', function () {
     [$subuser, $server] = generateTestAccount([SubuserPermission::WebsocketConnect]);
 
     runBackupCompletedListener($server);
+    runBackupCompletedListener($server, scheduled: true);
 
     Notification::assertNotSentTo($server->user, DatabaseNotification::class);
     Notification::assertNotSentTo($server->user, BackupCompletedNotification::class);
@@ -37,14 +39,37 @@ it('does not notify anyone by default', function () {
     Notification::assertNotSentTo($subuser, BackupCompletedNotification::class);
 });
 
-it('notifies owners who opted in', function () {
+it('notifies owners who opted in to manual backups only for manual backups', function () {
     Notification::fake();
 
     [$owner, $server] = generateTestAccount();
 
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, true);
+
+    runBackupCompletedListener($server, scheduled: true);
+
+    Notification::assertNotSentTo($owner, DatabaseNotification::class);
+    Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
 
     runBackupCompletedListener($server);
+
+    Notification::assertSentTo($owner, DatabaseNotification::class);
+    Notification::assertSentTo($owner, BackupCompletedNotification::class);
+});
+
+it('notifies owners who opted in to scheduled backups only for scheduled backups', function () {
+    Notification::fake();
+
+    [$owner, $server] = generateTestAccount();
+
+    $owner->updateServerSetting($server, ServerUserSettingKey::ScheduledBackupNotifications, true);
+
+    runBackupCompletedListener($server);
+
+    Notification::assertNotSentTo($owner, DatabaseNotification::class);
+    Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
+
+    runBackupCompletedListener($server, scheduled: true);
 
     Notification::assertSentTo($owner, DatabaseNotification::class);
     Notification::assertSentTo($owner, BackupCompletedNotification::class);
@@ -55,7 +80,7 @@ it('notifies subusers who opted in', function () {
 
     [$subuser, $server] = generateTestAccount([SubuserPermission::WebsocketConnect]);
 
-    $subuser->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+    $subuser->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, true);
 
     runBackupCompletedListener($server);
 
@@ -68,8 +93,8 @@ it('does not notify users who opted back out', function () {
 
     [$owner, $server] = generateTestAccount();
 
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, false);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, true);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, false);
 
     runBackupCompletedListener($server);
 
@@ -83,18 +108,22 @@ it('defaults backup notifications off for everyone', function () {
     /** @var User $subuser */
     $subuser = User::factory()->create();
 
-    expect($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeFalse()
-        ->and($subuser->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeFalse();
+    foreach (ServerUserSettingKey::cases() as $key) {
+        expect($owner->getServerSetting($server, $key))->toBeFalse()
+            ->and($subuser->getServerSetting($server, $key))->toBeFalse();
+    }
 });
 
 it('updates a single settings row per user and server', function () {
     [$owner, $server] = generateTestAccount();
 
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, false);
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, false);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, true);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ScheduledBackupNotifications, true);
 
     expect(ServerUserSettings::query()->where('user_id', $owner->id)->where('server_id', $server->id)->count())->toBe(1)
-        ->and($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeTrue();
+        ->and($owner->getServerSetting($server, ServerUserSettingKey::ManualBackupNotifications))->toBeTrue()
+        ->and($owner->getServerSetting($server, ServerUserSettingKey::ScheduledBackupNotifications))->toBeTrue();
 });
 
 it('drops unknown keys when updating settings', function () {
@@ -106,9 +135,9 @@ it('drops unknown keys when updating settings', function () {
         'settings' => ['unknown_key' => 'value'],
     ]);
 
-    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+    $owner->updateServerSetting($server, ServerUserSettingKey::ManualBackupNotifications, true);
 
     $settings = ServerUserSettings::query()->where('user_id', $owner->id)->where('server_id', $server->id)->value('settings');
 
-    expect($settings)->toBe([ServerUserSettingKey::BackupNotifications->value => true]);
+    expect($settings)->toBe([ServerUserSettingKey::ManualBackupNotifications->value => true]);
 });

--- a/tests/Feature/BackupNotificationSettingsTest.php
+++ b/tests/Feature/BackupNotificationSettingsTest.php
@@ -24,27 +24,30 @@ function runBackupCompletedListener(Server $server): void
     (new BackupCompletedListener())->handle(new BackupCompleted($backup));
 }
 
-it('notifies the server owner by default', function () {
-    Notification::fake();
-
-    [$owner, $server] = generateTestAccount();
-
-    runBackupCompletedListener($server);
-
-    Notification::assertSentTo($owner, DatabaseNotification::class);
-    Notification::assertSentTo($owner, BackupCompletedNotification::class);
-});
-
-it('does not notify subusers by default', function () {
+it('does not notify anyone by default', function () {
     Notification::fake();
 
     [$subuser, $server] = generateTestAccount([SubuserPermission::WebsocketConnect]);
 
     runBackupCompletedListener($server);
 
+    Notification::assertNotSentTo($server->user, DatabaseNotification::class);
+    Notification::assertNotSentTo($server->user, BackupCompletedNotification::class);
     Notification::assertNotSentTo($subuser, DatabaseNotification::class);
     Notification::assertNotSentTo($subuser, BackupCompletedNotification::class);
-    Notification::assertSentTo($server->user, DatabaseNotification::class);
+});
+
+it('notifies owners who opted in', function () {
+    Notification::fake();
+
+    [$owner, $server] = generateTestAccount();
+
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+
+    runBackupCompletedListener($server);
+
+    Notification::assertSentTo($owner, DatabaseNotification::class);
+    Notification::assertSentTo($owner, BackupCompletedNotification::class);
 });
 
 it('notifies subusers who opted in', function () {
@@ -60,11 +63,12 @@ it('notifies subusers who opted in', function () {
     Notification::assertSentTo($subuser, BackupCompletedNotification::class);
 });
 
-it('does not notify owners who opted out', function () {
+it('does not notify users who opted back out', function () {
     Notification::fake();
 
     [$owner, $server] = generateTestAccount();
 
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
     $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, false);
 
     runBackupCompletedListener($server);
@@ -73,26 +77,13 @@ it('does not notify owners who opted out', function () {
     Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
 });
 
-it('sends no email when the global config is disabled', function () {
-    Notification::fake();
-
-    config()->set('panel.email.send_backup_completed_notification', false);
-
-    [$owner, $server] = generateTestAccount();
-
-    runBackupCompletedListener($server);
-
-    Notification::assertSentTo($owner, DatabaseNotification::class);
-    Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
-});
-
-it('defaults backup notifications on for owners and off for subusers', function () {
+it('defaults backup notifications off for everyone', function () {
     [$owner, $server] = generateTestAccount();
 
     /** @var User $subuser */
     $subuser = User::factory()->create();
 
-    expect($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeTrue()
+    expect($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeFalse()
         ->and($subuser->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeFalse();
 });
 

--- a/tests/Feature/BackupNotificationSettingsTest.php
+++ b/tests/Feature/BackupNotificationSettingsTest.php
@@ -1,0 +1,123 @@
+<?php
+
+use App\Enums\ServerUserSettingKey;
+use App\Enums\SubuserPermission;
+use App\Events\Server\BackupCompleted;
+use App\Listeners\Server\BackupCompletedListener;
+use App\Models\Backup;
+use App\Models\BackupHost;
+use App\Models\Server;
+use App\Models\ServerUserSettings;
+use App\Models\User;
+use App\Notifications\BackupCompleted as BackupCompletedNotification;
+use Filament\Notifications\DatabaseNotification;
+use Illuminate\Support\Facades\Notification;
+
+function runBackupCompletedListener(Server $server): void
+{
+    /** @var Backup $backup */
+    $backup = Backup::factory()->create([
+        'server_id' => $server->id,
+        'backup_host_id' => BackupHost::factory()->create()->id,
+    ]);
+
+    (new BackupCompletedListener())->handle(new BackupCompleted($backup));
+}
+
+it('notifies the server owner by default', function () {
+    Notification::fake();
+
+    [$owner, $server] = generateTestAccount();
+
+    runBackupCompletedListener($server);
+
+    Notification::assertSentTo($owner, DatabaseNotification::class);
+    Notification::assertSentTo($owner, BackupCompletedNotification::class);
+});
+
+it('does not notify subusers by default', function () {
+    Notification::fake();
+
+    [$subuser, $server] = generateTestAccount([SubuserPermission::WebsocketConnect]);
+
+    runBackupCompletedListener($server);
+
+    Notification::assertNotSentTo($subuser, DatabaseNotification::class);
+    Notification::assertNotSentTo($subuser, BackupCompletedNotification::class);
+    Notification::assertSentTo($server->user, DatabaseNotification::class);
+});
+
+it('notifies subusers who opted in', function () {
+    Notification::fake();
+
+    [$subuser, $server] = generateTestAccount([SubuserPermission::WebsocketConnect]);
+
+    $subuser->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+
+    runBackupCompletedListener($server);
+
+    Notification::assertSentTo($subuser, DatabaseNotification::class);
+    Notification::assertSentTo($subuser, BackupCompletedNotification::class);
+});
+
+it('does not notify owners who opted out', function () {
+    Notification::fake();
+
+    [$owner, $server] = generateTestAccount();
+
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, false);
+
+    runBackupCompletedListener($server);
+
+    Notification::assertNotSentTo($owner, DatabaseNotification::class);
+    Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
+});
+
+it('sends no email when the global config is disabled', function () {
+    Notification::fake();
+
+    config()->set('panel.email.send_backup_completed_notification', false);
+
+    [$owner, $server] = generateTestAccount();
+
+    runBackupCompletedListener($server);
+
+    Notification::assertSentTo($owner, DatabaseNotification::class);
+    Notification::assertNotSentTo($owner, BackupCompletedNotification::class);
+});
+
+it('defaults backup notifications on for owners and off for subusers', function () {
+    [$owner, $server] = generateTestAccount();
+
+    /** @var User $subuser */
+    $subuser = User::factory()->create();
+
+    expect($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeTrue()
+        ->and($subuser->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeFalse();
+});
+
+it('updates a single settings row per user and server', function () {
+    [$owner, $server] = generateTestAccount();
+
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, false);
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+
+    expect(ServerUserSettings::query()->where('user_id', $owner->id)->where('server_id', $server->id)->count())->toBe(1)
+        ->and($owner->getServerSetting($server, ServerUserSettingKey::BackupNotifications))->toBeTrue();
+});
+
+it('drops unknown keys when updating settings', function () {
+    [$owner, $server] = generateTestAccount();
+
+    ServerUserSettings::factory()->create([
+        'user_id' => $owner->id,
+        'server_id' => $server->id,
+        'settings' => ['unknown_key' => 'value'],
+    ]);
+
+    $owner->updateServerSetting($server, ServerUserSettingKey::BackupNotifications, true);
+
+    $settings = ServerUserSettings::query()->where('user_id', $owner->id)->where('server_id', $server->id)->value('settings');
+
+    expect($settings)->toBe([ServerUserSettingKey::BackupNotifications->value => true]);
+});


### PR DESCRIPTION
1. Adds a server_user_settings table (user_id, server_id, JSON settings with enum-whitelisted keys)
2. Each user with access to a server can choose whether they receive backup notifications from it.
3. Owners and Subusers default off now for backup emails for new servers
4. Toggles live on the server Settings page and the Backups list header.
5. Split manual vs scheduled backups for notifications

<img width="1066" height="927" alt="image" src="https://github.com/user-attachments/assets/b1cfefd3-5c14-4680-a600-434c9003bba1" />

