### PR TITLE
Fix docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -93,7 +93,7 @@ COPY docker/crontab /etc/crontabs/crontab
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=5m --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=2m --retries=3 \
   CMD /bin/ash /healthcheck.sh
 
 EXPOSE 80 443

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -99,7 +99,7 @@ COPY docker/crontab /etc/crontabs/crontab
 COPY docker/entrypoint.sh /entrypoint.sh
 COPY docker/healthcheck.sh /healthcheck.sh
 
-HEALTHCHECK --interval=5m --timeout=10s --start-period=5s --retries=3 \
+HEALTHCHECK --interval=30s --timeout=10s --start-period=2m --retries=3 \
   CMD /bin/ash /healthcheck.sh
 
 EXPOSE 80 443

--- a/docker/healthcheck.sh
+++ b/docker/healthcheck.sh
@@ -1,7 +1,7 @@
 #!/bin/ash -e
 
-if [ ${SKIP_CADDY} ! "true" ]; then
-    curl -f http://localhost/up || exit 1
+if [ "${SKIP_CADDY:-false}" != "true" ]; then
+    curl -sf http://localhost/up || exit 1
 fi
 
 cgi-fcgi -bind -connect 127.0.0.1:9000 || exit 2


### PR DESCRIPTION
The `SKIP_CADDY` check in healthcheck.sh was invalid syntax, so the curl check against `/up` never actually ran and only php-fpm was being checked. Fixed the condition and bumped the check interval so a dead panel gets noticed in seconds instead of minutes.