### PR TITLE
Enable opcache and tune PHP in the docker image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -84,6 +84,9 @@ RUN mkdir -p /pelican-data/storage /var/run/supervisord \
     && chown -R www-data: /pelican-data .env ./storage ./bootstrap/cache /var/run/supervisord /var/www/html/public/storage \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
     && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
+# Configure PHP and PHP-FPM
+COPY docker/php/pelican.ini /usr/local/etc/php/conf.d/zz-pelican.ini
+COPY docker/php/pelican-pool.conf /usr/local/etc/php-fpm.d/zz-pelican.conf
 # Configure Supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/Caddyfile /etc/caddy/Caddyfile

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -5,6 +5,9 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.5-fpm-alpine
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions bcmath gd intl zip pcntl pdo_mysql pdo_pgsql bz2
+RUN install-php-extensions bcmath gd intl zip opcache pcntl pdo_mysql pdo_pgsql bz2
 
 RUN rm /usr/local/bin/install-php-extensions
+
+# Use the production php.ini shipped with the image as the baseline
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -5,9 +5,12 @@ FROM --platform=$TARGETOS/$TARGETARCH php:8.5-fpm-alpine AS base
 
 ADD --chmod=0755 https://github.com/mlocati/docker-php-extension-installer/releases/latest/download/install-php-extensions /usr/local/bin/
 
-RUN install-php-extensions bcmath gd intl zip pcntl pdo_mysql pdo_pgsql bz2
+RUN install-php-extensions bcmath gd intl zip opcache pcntl pdo_mysql pdo_pgsql bz2
 
 RUN rm /usr/local/bin/install-php-extensions
+
+# Use the production php.ini shipped with the image as the baseline
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini"
 
 # ================================
 # Stage 1-1: Composer Install
@@ -90,6 +93,9 @@ RUN mkdir -p /pelican-data/storage /var/run/supervisord \
     && chmod -R 770 /pelican-data ./storage ./bootstrap/cache /var/run/supervisord \
     && chown -R www-data: /usr/local/etc/php/ /usr/local/etc/php-fpm.d/ /var/www/html/composer.json /var/www/html/composer.lock
 
+# Configure PHP and PHP-FPM
+COPY docker/php/pelican.ini /usr/local/etc/php/conf.d/zz-pelican.ini
+COPY docker/php/pelican-pool.conf /usr/local/etc/php-fpm.d/zz-pelican.conf
 # Configure Supervisor
 COPY docker/supervisord.conf /etc/supervisord.conf
 COPY docker/Caddyfile /etc/caddy/Caddyfile

--- a/docker/entrypoint.sh
+++ b/docker/entrypoint.sh
@@ -66,6 +66,12 @@ fi
 echo "Optimizing Filament"
 php artisan filament:optimize
 
+# Note: config/route/event caches are intentionally NOT built here. Settings
+# live in .env and are edited at runtime, and plugins register providers (and
+# routes) at runtime - those caches would freeze them until the next restart.
+echo "Caching Blade views"
+php artisan view:cache
+
 # default to caddy not starting
 export SUPERVISORD_CADDY=false
 export CADDY_APP_URL="${APP_URL}"

--- a/docker/php/pelican-pool.conf
+++ b/docker/php/pelican-pool.conf
@@ -1,0 +1,12 @@
+; Pelican overrides for the default www pool.
+; The image default of pm.max_children = 5 caps the panel at five concurrent
+; PHP requests. Sizing assumes roughly 64-128MB per worker; lower
+; pm.max_children on very small hosts.
+[www]
+pm = dynamic
+pm.max_children = 15
+pm.start_servers = 4
+pm.min_spare_servers = 2
+pm.max_spare_servers = 8
+; recycle workers periodically to guard against memory leaks
+pm.max_requests = 500

--- a/docker/php/pelican.ini
+++ b/docker/php/pelican.ini
@@ -1,0 +1,14 @@
+; Pelican overrides, layered on top of php.ini-production
+
+; Filament recommends at least 256M
+memory_limit = 256M
+
+[opcache]
+opcache.enable = 1
+opcache.memory_consumption = 192
+opcache.interned_strings_buffer = 32
+opcache.max_accelerated_files = 30000
+; keep timestamp validation enabled so runtime plugin installs pick up
+; new and changed files without a container restart
+opcache.validate_timestamps = 1
+opcache.revalidate_freq = 2


### PR DESCRIPTION
The image was running with no opcache, default php.ini, and the stock fpm pool (max 5 workers). That means every request recompiles the whole framework. This turns opcache on, uses the production php.ini with a 256M memory limit, raises the pool to 15 workers, and caches blade views on boot.