### PR TITLE
Show php-fpm and queue worker output in docker logs

### DIFF
--- a/docker/supervisord.conf
+++ b/docker/supervisord.conf
@@ -25,11 +25,20 @@ password=dummy
 command=/usr/local/sbin/php-fpm -F
 autostart=true
 autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:queue-worker]
-command=/usr/local/bin/php /var/www/html/artisan queue:work --tries=3
+command=/usr/local/bin/php /var/www/html/artisan queue:work --tries=3 --max-time=3600
 autostart=true
 autorestart=true
+; give running jobs time to finish on shutdown instead of killing them
+; after supervisord's 10 second default
+stopwaitsecs=3600
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
+redirect_stderr=true
 
 [program:caddy]
 command=caddy run --config /etc/caddy/Caddyfile --adapter caddyfile
@@ -44,4 +53,6 @@ redirect_stderr=true
 command=supercronic -overlapping /etc/crontabs/crontab
 autostart=true
 autorestart=true
+stdout_logfile=/dev/fd/1
+stdout_logfile_maxbytes=0
 redirect_stderr=true


### PR DESCRIPTION
Only caddy's output made it to `docker logs` - php-fpm and the queue worker were writing to files under /tmp, so app errors and failed jobs were invisible. Route everything to stdout, and give the queue worker time to finish jobs on shutdown instead of killing them after 10 seconds.