### PR TITLE
Fix flaky allocation test

### DIFF
--- a/database/Factories/AllocationFactory.php
+++ b/database/Factories/AllocationFactory.php
@@ -23,7 +23,10 @@ class AllocationFactory extends Factory
     {
         return [
             'ip' => $this->faker->unique()->ipv4(),
-            'port' => $this->faker->unique()->numberBetween(1024, 65535),
+            // stay above the ports some tests hardcode (e.g. 5000-5005) on the
+            // same node and ip, otherwise the unique (node_id, ip, port) index
+            // makes those tests randomly fail
+            'port' => $this->faker->unique()->numberBetween(10000, 65535),
             'node_id' => Node::factory(),
         ];
     }


### PR DESCRIPTION
The allocation factory picks a random port between 1024 and 65535, and a few tests hardcode ports 5000-5005 on the same node and ip as the server's factory allocation. When the random port happens to land in that range, the unique (node_id, ip, port) index fails the test - the SQLite job on #2464 hit exactly this. Raise the factory floor to 10000 so the two can never overlap.