### PR TITLE
Fix activity tab crash after Filament v5.7 bump

### DIFF
--- a/app/Filament/Admin/Resources/Users/UserResource.php
+++ b/app/Filament/Admin/Resources/Users/UserResource.php
@@ -490,7 +490,7 @@ class UserResource extends Resource
                         ->schema([
                             TextEntry::make('log')
                                 ->hiddenLabel()
-                                ->state(fn (ActivityLog $log) => new HtmlString($log->htmlable())),
+                                ->state(fn (ActivityLog $record) => new HtmlString($record->htmlable())),
                         ]),
                 ]),
         ];

--- a/app/Filament/Pages/Auth/EditProfile.php
+++ b/app/Filament/Pages/Auth/EditProfile.php
@@ -453,7 +453,7 @@ class EditProfile extends BaseEditProfile
                         ->schema([
                             TextEntry::make('log')
                                 ->hiddenLabel()
-                                ->state(fn (ActivityLog $log) => new HtmlString($log->htmlable())),
+                                ->state(fn (ActivityLog $record) => new HtmlString($record->htmlable())),
                         ]),
                 ]),
             Tab::make('customization')

--- a/tests/Filament/EditProfileTest.php
+++ b/tests/Filament/EditProfileTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Facades\Activity;
+use App\Filament\Pages\Auth\EditProfile;
+use App\Models\User;
+use Filament\Facades\Filament;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel('app');
+});
+
+it('renders the activity tab when the user has activity logs', function () {
+    /** @var User $user */
+    $user = User::factory()->create();
+
+    // Prior to the fix the activity repeater's TextEntry closure declared a
+    // `$log` parameter that Filament could not inject, throwing a
+    // BindingResolutionException while rendering this page. A logged activity
+    // is required so the repeater actually renders a row and evaluates the closure.
+    Activity::event('user:api-key.create')
+        ->actor($user)
+        ->subject($user)
+        ->property('identifier', 'pacc_test')
+        ->log();
+
+    $this->actingAs($user);
+
+    livewire(EditProfile::class)
+        ->assertSuccessful();
+});


### PR DESCRIPTION
Filament v5.7 changed how closure params get resolved, so the activity tab TextEntry closure that used `$log` stopped resolving and threw `BindingResolutionException: [$log] was unresolvable`.

Renamed the param to `$record` in both spots (profile page + admin user resource) so it resolves by name instead of relying on the type-hint. Added a render test for the profile activity tab too.

Fixes #2442