### PR TITLE
Fix silent failure importing renamed plugin zips

### DIFF
--- a/app/Filament/Admin/Resources/Plugins/PluginResource.php
+++ b/app/Filament/Admin/Resources/Plugins/PluginResource.php
@@ -263,10 +263,6 @@ class PluginResource extends Resource
                             /** @var UploadedFile $file */
                             $file = $data['file'];
 
-                            $pluginName = str($file->getClientOriginalName())->basename()->before('.zip')->toString();
-
-                            throw_if(Plugin::where('id', $pluginName)->exists(), new Exception(trans('admin/plugin.notifications.import_exists')));
-
                             $pluginService->downloadPluginFromFile($file);
 
                             Notification::make()
@@ -300,10 +296,6 @@ class PluginResource extends Resource
                     ])
                     ->action(function ($data, $livewire, PluginService $pluginService) {
                         try {
-                            $pluginName = str($data['url'])->before('.zip')->explode('/')->last();
-
-                            throw_if(Plugin::where('id', $pluginName)->exists(), new Exception(trans('admin/plugin.notifications.import_exists')));
-
                             $pluginService->downloadPluginFromUrl($data['url']);
 
                             Notification::make()

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -379,20 +379,37 @@ class PluginService
         throw_if($manifest === null, new Exception(trans('admin/plugin.notifications.import_no_manifest')));
 
         $data = File::json($manifest, JSON_THROW_ON_ERROR);
-        $pluginName = Str::lower($data['id'] ?? '');
-        throw_if($pluginName === '', new Exception(trans('admin/plugin.notifications.import_no_manifest')));
+        $id = $data['id'] ?? null;
+        throw_if(!is_string($id) || trim($id) === '', new Exception(trans('admin/plugin.notifications.import_no_manifest')));
 
+        $pluginName = Str::lower($id);
         $target = plugin_path($pluginName);
+        $source = dirname($manifest);
 
-        if ($cleanDownload) {
-            File::deleteDirectory($target);
+        // For a clean re-download of an existing plugin, set the current install aside as a
+        // rollback until the new copy is in place, so a failed move can't leave nothing behind.
+        $rollback = null;
+        if ($cleanDownload && File::isDirectory($target)) {
+            $rollback = $target . '.bak';
+            File::deleteDirectory($rollback);
+            File::moveDirectory($target, $rollback);
         }
 
         throw_if(File::isDirectory($target), new Exception(trans('admin/plugin.notifications.import_exists')));
 
         // Move the folder containing plugin.json to plugins/<id> so the layout is correct
         // regardless of the archive's internal folder name.
-        File::moveDirectory(dirname($manifest), $target);
+        if (!File::moveDirectory($source, $target)) {
+            if ($rollback !== null) {
+                File::moveDirectory($rollback, $target);
+            }
+
+            throw new Exception('Could not move plugin into place.');
+        }
+
+        if ($rollback !== null) {
+            File::deleteDirectory($rollback);
+        }
 
         return $pluginName;
     }

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -347,11 +347,18 @@ class PluginService
     {
         // Validate file size to prevent zip bombs
         $maxSize = config('panel.plugin.max_import_size');
-        throw_if($file->getSize() > $maxSize, new Exception("Zip file too large. ($maxSize  MiB)"));
+        $maxSizeLabel = round($maxSize / 1024 / 1024, 2);
+        throw_if($file->getSize() > $maxSize, new Exception("Zip file too large. ($maxSizeLabel MiB)"));
 
         $zip = new ZipArchive();
 
         throw_unless($zip->open($file->getPathname()), new Exception('Could not open zip file.'));
+
+        // The check above only sees the compressed bytes, which say nothing about what the
+        // archive expands to — a small, highly compressible zip can still fill the plugins
+        // volume. Total the uncompressed entry sizes while walking the entries and bail as
+        // soon as they exceed the same limit, before anything is written to disk.
+        $uncompressedSize = 0;
 
         // Validate zip contents before extraction
         for ($i = 0; $i < $zip->numFiles; $i++) {
@@ -359,6 +366,14 @@ class PluginService
             if (Str::contains($filename, '..') || Str::startsWith($filename, '/')) {
                 $zip->close();
                 throw new Exception('Zip file contains invalid path traversal sequences.');
+            }
+
+            $stat = $zip->statIndex($i) ?: [];
+            $uncompressedSize += $stat['size'] ?? 0;
+
+            if ($uncompressedSize > $maxSize) {
+                $zip->close();
+                throw new Exception("Zip file contents too large. ($maxSizeLabel MiB)");
             }
         }
 
@@ -463,7 +478,8 @@ class PluginService
 
         // Validate file size to prevent zip bombs
         $maxSize = config('panel.plugin.max_import_size');
-        throw_if(strlen($content) > $maxSize, new InvalidFileUploadException("Zip file too large. ($maxSize  MiB)"));
+        $maxSizeLabel = round($maxSize / 1024 / 1024, 2);
+        throw_if(strlen($content) > $maxSize, new InvalidFileUploadException("Zip file too large. ($maxSizeLabel MiB)"));
 
         throw_unless(file_put_contents($tmpPath, $content), new InvalidFileUploadException('Could not write temporary file.'));
 

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -310,7 +310,7 @@ class PluginService
         $downloadUrl = $plugin->getDownloadUrlForUpdate();
         throw_unless($downloadUrl, new Exception('No download url found.'));
 
-        $this->downloadPluginFromUrl($downloadUrl, true);
+        $this->downloadPluginFromUrl($downloadUrl);
 
         Plugin::refreshRows();
         $plugin = $plugin->refresh();
@@ -343,7 +343,7 @@ class PluginService
     }
 
     /** @throws Exception */
-    public function downloadPluginFromFile(UploadedFile $file, bool $cleanDownload = false): string
+    public function downloadPluginFromFile(UploadedFile $file): string
     {
         // Validate file size to prevent zip bombs
         $maxSize = config('panel.plugin.max_import_size');
@@ -399,18 +399,16 @@ class PluginService
         $target = plugin_path($pluginName);
         $source = dirname($manifest);
 
-        // For a clean re-download of an existing plugin, set the current install aside as a
+        // Importing over an existing plugin replaces it. Set the current install aside as a
         // rollback until the new copy is in place, so a failed move can't leave nothing behind.
         // The backup is a dotfile so discovery ignores it during the swap; temp, target and
         // backup all sit under plugins/, so each move is a same-filesystem rename.
         $rollback = null;
-        if ($cleanDownload && File::isDirectory($target)) {
+        if (File::isDirectory($target)) {
             $rollback = plugin_path('.' . $pluginName . '.bak');
             File::deleteDirectory($rollback);
             throw_unless(File::moveDirectory($target, $rollback), new Exception('Could not set the existing plugin aside.'));
         }
-
-        throw_if(File::isDirectory($target), new Exception(trans('admin/plugin.notifications.import_exists')));
 
         // Move the folder containing plugin.json to plugins/<id> so the layout is correct
         // regardless of the archive's internal folder name.
@@ -451,7 +449,7 @@ class PluginService
     }
 
     /** @throws Exception */
-    public function downloadPluginFromUrl(string $url, bool $cleanDownload = false): string
+    public function downloadPluginFromUrl(string $url): string
     {
         $basename = pathinfo($url, PATHINFO_BASENAME);
         $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
@@ -465,7 +463,7 @@ class PluginService
 
         throw_unless(file_put_contents($tmpPath, $content), new InvalidFileUploadException('Could not write temporary file.'));
 
-        return $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'), $cleanDownload);
+        return $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'));
     }
 
     public function deletePlugin(Plugin $plugin): void

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -310,7 +310,7 @@ class PluginService
         $downloadUrl = $plugin->getDownloadUrlForUpdate();
         throw_unless($downloadUrl, new Exception('No download url found.'));
 
-        $this->downloadPluginFromUrl($downloadUrl);
+        $this->downloadPluginFromUrl($downloadUrl, $plugin->id);
 
         Plugin::refreshRows();
         $plugin = $plugin->refresh();
@@ -343,7 +343,7 @@ class PluginService
     }
 
     /** @throws Exception */
-    public function downloadPluginFromFile(UploadedFile $file): string
+    public function downloadPluginFromFile(UploadedFile $file, ?string $expectedId = null): string
     {
         // Validate file size to prevent zip bombs
         $maxSize = config('panel.plugin.max_import_size');
@@ -395,6 +395,10 @@ class PluginService
         // "../../evil" that would escape the plugins directory when passed to plugin_path().
         $pluginName = Str::lower(trim($id));
         throw_unless(preg_match('/^[a-z0-9][a-z0-9._-]*$/', $pluginName), new Exception(trans('admin/plugin.notifications.import_invalid_id')));
+
+        // When updating a known plugin, the archive must be for that same plugin — reject a
+        // mismatched id before moving anything, so an update can't overwrite a different plugin.
+        throw_if($expectedId !== null && $pluginName !== $expectedId, new Exception(trans('admin/plugin.notifications.import_id_mismatch', ['expected' => $expectedId, 'actual' => $pluginName])));
 
         $target = plugin_path($pluginName);
         $source = dirname($manifest);
@@ -449,7 +453,7 @@ class PluginService
     }
 
     /** @throws Exception */
-    public function downloadPluginFromUrl(string $url): string
+    public function downloadPluginFromUrl(string $url, ?string $expectedId = null): string
     {
         $basename = pathinfo($url, PATHINFO_BASENAME);
         $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
@@ -463,7 +467,7 @@ class PluginService
 
         throw_unless(file_put_contents($tmpPath, $content), new InvalidFileUploadException('Could not write temporary file.'));
 
-        return $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'));
+        return $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'), $expectedId);
     }
 
     public function deletePlugin(Plugin $plugin): void

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -343,7 +343,7 @@ class PluginService
     }
 
     /** @throws Exception */
-    public function downloadPluginFromFile(UploadedFile $file, bool $cleanDownload = false): void
+    public function downloadPluginFromFile(UploadedFile $file, bool $cleanDownload = false): string
     {
         // Validate file size to prevent zip bombs
         $maxSize = config('panel.plugin.max_import_size');
@@ -362,24 +362,64 @@ class PluginService
             }
         }
 
-        $pluginName = str($file->getClientOriginalName())->basename()->before('.zip')->toString();
+        // Extract to a temporary directory first so we can derive the plugin's identity from
+        // its own plugin.json rather than trusting the (possibly renamed) upload filename.
+        $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
 
-        if ($cleanDownload) {
-            File::deleteDirectory(plugin_path($pluginName));
-        }
-
-        $extractPath = $zip->locateName($pluginName . '/plugin.json') !== false ? base_path('plugins') : plugin_path($pluginName);
-
-        if (!$zip->extractTo($extractPath)) {
+        if (!$zip->extractTo($tmpDir->path())) {
             $zip->close();
             throw new Exception('Could not extract zip file.');
         }
 
         $zip->close();
+
+        // Locate plugin.json, either at the archive root (flat zip) or one level deep
+        // (single top-level folder). Prefer the shallowest match.
+        $manifest = $this->locatePluginManifest($tmpDir->path());
+        throw_if($manifest === null, new Exception(trans('admin/plugin.notifications.import_no_manifest')));
+
+        $data = File::json($manifest, JSON_THROW_ON_ERROR);
+        $pluginName = Str::lower($data['id'] ?? '');
+        throw_if($pluginName === '', new Exception(trans('admin/plugin.notifications.import_no_manifest')));
+
+        $target = plugin_path($pluginName);
+
+        if ($cleanDownload) {
+            File::deleteDirectory($target);
+        }
+
+        throw_if(File::isDirectory($target), new Exception(trans('admin/plugin.notifications.import_exists')));
+
+        // Move the folder containing plugin.json to plugins/<id> so the layout is correct
+        // regardless of the archive's internal folder name.
+        File::moveDirectory(dirname($manifest), $target);
+
+        return $pluginName;
+    }
+
+    /**
+     * Find a plugin.json inside an extracted archive, either at its root or within a single
+     * top-level directory. Returns the absolute path to the manifest, or null if none exists.
+     */
+    private function locatePluginManifest(string $path): ?string
+    {
+        $rootManifest = join_paths($path, 'plugin.json');
+        if (File::exists($rootManifest)) {
+            return $rootManifest;
+        }
+
+        foreach (File::directories($path) as $directory) {
+            $manifest = join_paths($directory, 'plugin.json');
+            if (File::exists($manifest)) {
+                return $manifest;
+            }
+        }
+
+        return null;
     }
 
     /** @throws Exception */
-    public function downloadPluginFromUrl(string $url, bool $cleanDownload = false): void
+    public function downloadPluginFromUrl(string $url, bool $cleanDownload = false): string
     {
         $basename = pathinfo($url, PATHINFO_BASENAME);
         $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
@@ -393,7 +433,7 @@ class PluginService
 
         throw_unless(file_put_contents($tmpPath, $content), new InvalidFileUploadException('Could not write temporary file.'));
 
-        $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'), $cleanDownload);
+        return $this->downloadPluginFromFile(new UploadedFile($tmpPath, $basename, 'application/zip'), $cleanDownload);
     }
 
     public function deletePlugin(Plugin $plugin): void

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -362,11 +362,19 @@ class PluginService
             }
         }
 
-        // Extract to a temporary directory first so we can derive the plugin's identity from
-        // its own plugin.json rather than trusting the (possibly renamed) upload filename.
-        $tmpDir = TemporaryDirectory::make()->deleteWhenDestroyed();
+        // Extract into a temporary directory that lives on the same filesystem as the plugins
+        // directory (named as a dotfile so plugin discovery ignores it). Deriving the id from
+        // the extracted plugin.json — rather than the upload filename — means a renamed zip
+        // still imports, and keeping temp + target on one volume makes every move below an
+        // atomic same-filesystem rename instead of a cross-device copy that can fail.
+        $tmpDir = (new TemporaryDirectory(base_path('plugins')))
+            ->name('.import-' . Str::random(16))
+            ->deleteWhenDestroyed()
+            ->create();
 
-        if (!$zip->extractTo($tmpDir->path())) {
+        $extractPath = $tmpDir->path('contents');
+
+        if (!$zip->extractTo($extractPath)) {
             $zip->close();
             throw new Exception('Could not extract zip file.');
         }
@@ -375,24 +383,31 @@ class PluginService
 
         // Locate plugin.json, either at the archive root (flat zip) or one level deep
         // (single top-level folder). Prefer the shallowest match.
-        $manifest = $this->locatePluginManifest($tmpDir->path());
+        $manifest = $this->locatePluginManifest($extractPath);
         throw_if($manifest === null, new Exception(trans('admin/plugin.notifications.import_no_manifest')));
 
         $data = File::json($manifest, JSON_THROW_ON_ERROR);
         $id = $data['id'] ?? null;
         throw_if(!is_string($id) || trim($id) === '', new Exception(trans('admin/plugin.notifications.import_no_manifest')));
 
-        $pluginName = Str::lower($id);
+        // The id becomes the install directory name and must equal it once installed (see
+        // Plugin::getRows()), so guard against anything that isn't a safe slug — e.g. an id of
+        // "../../evil" that would escape the plugins directory when passed to plugin_path().
+        $pluginName = Str::lower(trim($id));
+        throw_unless(preg_match('/^[a-z0-9][a-z0-9._-]*$/', $pluginName), new Exception(trans('admin/plugin.notifications.import_invalid_id')));
+
         $target = plugin_path($pluginName);
         $source = dirname($manifest);
 
         // For a clean re-download of an existing plugin, set the current install aside as a
         // rollback until the new copy is in place, so a failed move can't leave nothing behind.
+        // The backup is a dotfile so discovery ignores it during the swap; temp, target and
+        // backup all sit under plugins/, so each move is a same-filesystem rename.
         $rollback = null;
         if ($cleanDownload && File::isDirectory($target)) {
-            $rollback = $target . '.bak';
+            $rollback = plugin_path('.' . $pluginName . '.bak');
             File::deleteDirectory($rollback);
-            File::moveDirectory($target, $rollback);
+            throw_unless(File::moveDirectory($target, $rollback), new Exception('Could not set the existing plugin aside.'));
         }
 
         throw_if(File::isDirectory($target), new Exception(trans('admin/plugin.notifications.import_exists')));

--- a/lang/en/admin/plugin.php
+++ b/lang/en/admin/plugin.php
@@ -67,6 +67,7 @@ return [
 
         'imported' => 'Plugin imported',
         'import_exists' => 'A plugin with that id already exists',
+        'import_no_manifest' => 'The zip does not contain a valid plugin.json',
         'import_failed' => 'Could not import plugin',
     ],
 ];

--- a/lang/en/admin/plugin.php
+++ b/lang/en/admin/plugin.php
@@ -69,6 +69,7 @@ return [
         'import_exists' => 'A plugin with that id already exists',
         'import_no_manifest' => 'The zip does not contain a valid plugin.json',
         'import_invalid_id' => 'The plugin.json contains an invalid id',
+        'import_id_mismatch' => 'The zip is for plugin ":actual", not ":expected"',
         'import_failed' => 'Could not import plugin',
     ],
 ];

--- a/lang/en/admin/plugin.php
+++ b/lang/en/admin/plugin.php
@@ -68,6 +68,7 @@ return [
         'imported' => 'Plugin imported',
         'import_exists' => 'A plugin with that id already exists',
         'import_no_manifest' => 'The zip does not contain a valid plugin.json',
+        'import_invalid_id' => 'The plugin.json contains an invalid id',
         'import_failed' => 'Could not import plugin',
     ],
 ];

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -200,6 +200,38 @@ class PluginServiceTest extends IntegrationTestCase
         $this->service->downloadPluginFromFile($file);
     }
 
+    public function test_import_rejects_a_zip_that_expands_beyond_the_configured_max(): void
+    {
+        // Clean up in case a regression lets the archive through and it actually installs.
+        $this->importedPlugins[] = 'zip-bomb';
+
+        config()->set('panel.plugin.max_import_size', 4096);
+
+        $file = $this->makeUpload('zip-bomb.zip', [
+            'zip-bomb/plugin.json' => $this->manifest('zip-bomb'),
+            'zip-bomb/payload.txt' => str_repeat('a', 100_000),
+        ]);
+
+        // The archive compresses down small enough to clear the compressed-size check, so only
+        // the uncompressed total catches it.
+        $this->assertLessThan(4096, $file->getSize());
+
+        $thrown = null;
+
+        try {
+            $this->service->downloadPluginFromFile($file);
+        } catch (Exception $exception) {
+            $thrown = $exception;
+        }
+
+        $this->assertNotNull($thrown, 'Expected the oversized archive to be rejected.');
+        $this->assertStringContainsString('Zip file contents too large', $thrown->getMessage());
+
+        // Nothing should have been written: no install, and no leftover extraction directory.
+        $this->assertDirectoryDoesNotExist(plugin_path('zip-bomb'));
+        $this->assertSame([], File::glob(plugin_path('.import-*')));
+    }
+
     public function test_import_from_url_downloads_and_installs_the_plugin(): void
     {
         $this->importedPlugins[] = 'test-url-plugin';

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -173,48 +173,34 @@ class PluginServiceTest extends IntegrationTestCase
         ];
     }
 
-    public function test_import_rejects_a_duplicate_plugin(): void
-    {
-        $this->importedPlugins[] = 'test-dupe-plugin';
-
-        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
-            'test-dupe-plugin/plugin.json' => $this->manifest('test-dupe-plugin'),
-        ]));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_exists'));
-
-        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
-            'test-dupe-plugin/plugin.json' => $this->manifest('test-dupe-plugin'),
-        ]));
-    }
-
-    public function test_clean_download_replaces_the_existing_plugin(): void
+    public function test_import_over_an_existing_plugin_replaces_it(): void
     {
         $this->importedPlugins[] = 'test-replace-plugin';
 
         $this->service->downloadPluginFromFile($this->makeUpload('test-replace-plugin.zip', [
             'test-replace-plugin/plugin.json' => $this->manifest('test-replace-plugin', '1.0.0'),
-        ]), true);
+        ]));
 
         $this->assertSame('1.0.0', $this->installedVersion('test-replace-plugin'));
 
-        $this->service->downloadPluginFromFile($this->makeUpload('test-replace-plugin.zip', [
+        // Re-importing the same id is allowed and replaces the existing install.
+        $id = $this->service->downloadPluginFromFile($this->makeUpload('test-replace-plugin.zip', [
             'test-replace-plugin/plugin.json' => $this->manifest('test-replace-plugin', '2.0.0'),
-        ]), true);
+        ]));
 
         // The new copy is in place and no rollback backup is left behind.
+        $this->assertSame('test-replace-plugin', $id);
         $this->assertSame('2.0.0', $this->installedVersion('test-replace-plugin'));
         $this->assertDirectoryDoesNotExist(plugin_path('.test-replace-plugin.bak'));
     }
 
-    public function test_clean_download_keeps_the_existing_plugin_when_the_move_fails(): void
+    public function test_import_keeps_the_existing_plugin_when_the_move_fails(): void
     {
         $this->importedPlugins[] = 'test-clean-plugin';
 
         $this->service->downloadPluginFromFile($this->makeUpload('test-clean-plugin.zip', [
             'test-clean-plugin/plugin.json' => $this->manifest('test-clean-plugin', '1.0.0'),
-        ]), true);
+        ]));
 
         // Force only the move into plugins/<id> to fail, standing in for a filesystem-level
         // failure mid-replace. The set-aside and restore moves (to/from the .bak dir) run for
@@ -235,7 +221,7 @@ class PluginServiceTest extends IntegrationTestCase
         ]);
 
         try {
-            $this->service->downloadPluginFromFile($file, true);
+            $this->service->downloadPluginFromFile($file);
             $this->fail('Expected the import to fail.');
         } catch (Exception $e) {
             $this->assertSame('Could not move plugin into place.', $e->getMessage());

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use ZipArchive;
 
@@ -27,9 +28,15 @@ class PluginServiceTest extends IntegrationTestCase
 
     protected function tearDown(): void
     {
-        // Clean up anything the service extracted into the real plugins directory.
+        // Clean up anything the service touched in the real plugins directory: installed
+        // plugins, their rollback backups, and any leftover extraction working directories.
         foreach ($this->importedPlugins as $id) {
             File::deleteDirectory(plugin_path($id));
+            File::deleteDirectory(plugin_path('.' . $id . '.bak'));
+        }
+
+        foreach (File::glob(plugin_path('.import-*')) as $leftover) {
+            File::deleteDirectory($leftover);
         }
 
         parent::tearDown();
@@ -40,7 +47,7 @@ class PluginServiceTest extends IntegrationTestCase
         // Zip contains a top-level folder "test-import-plugin", but the upload is renamed as
         // a browser would on a duplicate download.
         $file = $this->makeUpload('test-import-plugin(1).zip', [
-            'test-import-plugin/plugin.json' => json_encode(['id' => 'test-import-plugin']),
+            'test-import-plugin/plugin.json' => $this->manifest('test-import-plugin'),
         ]);
 
         $this->importedPlugins[] = 'test-import-plugin';
@@ -56,7 +63,7 @@ class PluginServiceTest extends IntegrationTestCase
     public function test_import_handles_flat_zip_without_a_top_level_folder(): void
     {
         $file = $this->makeUpload('renamed(2).zip', [
-            'plugin.json' => json_encode(['id' => 'test-flat-plugin']),
+            'plugin.json' => $this->manifest('test-flat-plugin'),
         ]);
 
         $this->importedPlugins[] = 'test-flat-plugin';
@@ -65,6 +72,32 @@ class PluginServiceTest extends IntegrationTestCase
 
         $this->assertSame('test-flat-plugin', $id);
         $this->assertFileExists(plugin_path('test-flat-plugin', 'plugin.json'));
+    }
+
+    public function test_import_lowercases_the_manifest_id(): void
+    {
+        $file = $this->makeUpload('Test-Upper.zip', [
+            'Test-Upper/plugin.json' => $this->manifest('Test-Upper'),
+        ]);
+
+        $this->importedPlugins[] = 'test-upper';
+
+        $id = $this->service->downloadPluginFromFile($file);
+
+        $this->assertSame('test-upper', $id);
+        $this->assertFileExists(plugin_path('test-upper', 'plugin.json'));
+    }
+
+    public function test_import_cleans_up_its_extraction_directory(): void
+    {
+        $this->importedPlugins[] = 'test-cleanup-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-cleanup-plugin.zip', [
+            'test-cleanup-plugin/plugin.json' => $this->manifest('test-cleanup-plugin'),
+        ]));
+
+        // The temporary ".import-*" working directory must not linger under plugins/.
+        $this->assertSame([], File::glob(plugin_path('.import-*')));
     }
 
     public function test_import_without_a_manifest_fails_loudly(): void
@@ -91,17 +124,101 @@ class PluginServiceTest extends IntegrationTestCase
         $this->service->downloadPluginFromFile($file);
     }
 
+    public function test_import_with_a_missing_id_fails_loudly(): void
+    {
+        $file = $this->makeUpload('no-id.zip', [
+            'plugin.json' => json_encode(['name' => 'No Id']),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    /**
+     * @param  string  $id  an id that is a non-empty string but not a safe directory slug
+     */
+    #[DataProvider('unsafeIds')]
+    public function test_import_rejects_an_unsafe_plugin_id(string $id): void
+    {
+        // A clean entry name (so it passes the archive path-traversal check) whose manifest
+        // still carries a dangerous id must be rejected before anything is moved into place.
+        $file = $this->makeUpload('sneaky.zip', [
+            'plugin.json' => json_encode(['id' => $id]),
+        ]);
+
+        try {
+            $this->service->downloadPluginFromFile($file);
+            $this->fail('Expected the import to be rejected for id: ' . $id);
+        } catch (Exception $e) {
+            $this->assertSame(trans('admin/plugin.notifications.import_invalid_id'), $e->getMessage());
+        }
+
+        // Nothing should have escaped the plugins directory.
+        $this->assertDirectoryDoesNotExist(base_path('evil'));
+        $this->assertDirectoryDoesNotExist(base_path('plugins/../evil'));
+    }
+
+    /** @return array<string, array{string}> */
+    public static function unsafeIds(): array
+    {
+        return [
+            'parent traversal' => ['../../evil'],
+            'single parent' => ['../evil'],
+            'contains slash' => ['foo/bar'],
+            'leading dot' => ['.hidden'],
+            'just dots' => ['..'],
+            'contains space' => ['foo bar'],
+        ];
+    }
+
+    public function test_import_rejects_a_duplicate_plugin(): void
+    {
+        $this->importedPlugins[] = 'test-dupe-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
+            'test-dupe-plugin/plugin.json' => $this->manifest('test-dupe-plugin'),
+        ]));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_exists'));
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
+            'test-dupe-plugin/plugin.json' => $this->manifest('test-dupe-plugin'),
+        ]));
+    }
+
+    public function test_clean_download_replaces_the_existing_plugin(): void
+    {
+        $this->importedPlugins[] = 'test-replace-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-replace-plugin.zip', [
+            'test-replace-plugin/plugin.json' => $this->manifest('test-replace-plugin', '1.0.0'),
+        ]), true);
+
+        $this->assertSame('1.0.0', $this->installedVersion('test-replace-plugin'));
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-replace-plugin.zip', [
+            'test-replace-plugin/plugin.json' => $this->manifest('test-replace-plugin', '2.0.0'),
+        ]), true);
+
+        // The new copy is in place and no rollback backup is left behind.
+        $this->assertSame('2.0.0', $this->installedVersion('test-replace-plugin'));
+        $this->assertDirectoryDoesNotExist(plugin_path('.test-replace-plugin.bak'));
+    }
+
     public function test_clean_download_keeps_the_existing_plugin_when_the_move_fails(): void
     {
         $this->importedPlugins[] = 'test-clean-plugin';
 
         $this->service->downloadPluginFromFile($this->makeUpload('test-clean-plugin.zip', [
-            'test-clean-plugin/plugin.json' => json_encode(['id' => 'test-clean-plugin', 'version' => '1.0.0']),
+            'test-clean-plugin/plugin.json' => $this->manifest('test-clean-plugin', '1.0.0'),
         ]), true);
 
-        // Force the move into plugins/<id> to fail, standing in for any filesystem-level
-        // failure mid-replace. The set-aside and restore moves (to/from the .bak dir) run
-        // for real so we can assert the original install survives.
+        // Force only the move into plugins/<id> to fail, standing in for a filesystem-level
+        // failure mid-replace. The set-aside and restore moves (to/from the .bak dir) run for
+        // real so we can prove the original install is restored intact.
         $real = new Filesystem();
         File::partialMock()
             ->shouldReceive('moveDirectory')
@@ -114,34 +231,30 @@ class PluginServiceTest extends IntegrationTestCase
             });
 
         $file = $this->makeUpload('test-clean-plugin.zip', [
-            'test-clean-plugin/plugin.json' => json_encode(['id' => 'test-clean-plugin', 'version' => '2.0.0']),
+            'test-clean-plugin/plugin.json' => $this->manifest('test-clean-plugin', '2.0.0'),
         ]);
 
         try {
             $this->service->downloadPluginFromFile($file, true);
             $this->fail('Expected the import to fail.');
-        } catch (Exception) {
-            // The original install must still be there after a failed clean download.
+        } catch (Exception $e) {
+            $this->assertSame('Could not move plugin into place.', $e->getMessage());
         }
 
-        $this->assertFileExists(plugin_path('test-clean-plugin', 'plugin.json'));
-        $this->assertDirectoryDoesNotExist(plugin_path('test-clean-plugin.bak'));
+        // The original 1.0.0 install must survive — not the failed 2.0.0 replacement — and the
+        // backup directory must be gone.
+        $this->assertSame('1.0.0', $this->installedVersion('test-clean-plugin'));
+        $this->assertDirectoryDoesNotExist(plugin_path('.test-clean-plugin.bak'));
     }
 
-    public function test_import_rejects_a_duplicate_plugin(): void
+    private function installedVersion(string $id): string
     {
-        $this->importedPlugins[] = 'test-dupe-plugin';
+        return File::json(plugin_path($id, 'plugin.json'))['version'];
+    }
 
-        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
-            'test-dupe-plugin/plugin.json' => json_encode(['id' => 'test-dupe-plugin']),
-        ]));
-
-        $this->expectException(Exception::class);
-        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_exists'));
-
-        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
-            'test-dupe-plugin/plugin.json' => json_encode(['id' => 'test-dupe-plugin']),
-        ]));
+    private function manifest(string $id, string $version = '1.0.0'): string
+    {
+        return json_encode(['id' => $id, 'version' => $version]);
     }
 
     /**

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -194,6 +194,49 @@ class PluginServiceTest extends IntegrationTestCase
         $this->assertDirectoryDoesNotExist(plugin_path('.test-replace-plugin.bak'));
     }
 
+    public function test_import_succeeds_when_the_id_matches_the_expected_id(): void
+    {
+        $this->importedPlugins[] = 'test-expected-plugin';
+
+        $id = $this->service->downloadPluginFromFile($this->makeUpload('test-expected-plugin.zip', [
+            'test-expected-plugin/plugin.json' => $this->manifest('test-expected-plugin'),
+        ]), 'test-expected-plugin');
+
+        $this->assertSame('test-expected-plugin', $id);
+        $this->assertFileExists(plugin_path('test-expected-plugin', 'plugin.json'));
+    }
+
+    public function test_import_rejects_an_archive_for_a_different_plugin_than_expected(): void
+    {
+        // Stand in for an update whose archive actually claims to be a *different* plugin than
+        // the one being updated. It must be rejected before anything is written, so the update
+        // can neither reinstall the wrong plugin nor overwrite an unrelated one.
+        $this->importedPlugins[] = 'test-target-plugin';
+        $this->importedPlugins[] = 'test-other-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-target-plugin.zip', [
+            'test-target-plugin/plugin.json' => $this->manifest('test-target-plugin', '1.0.0'),
+        ]));
+
+        $file = $this->makeUpload('update.zip', [
+            'test-other-plugin/plugin.json' => $this->manifest('test-other-plugin', '9.9.9'),
+        ]);
+
+        try {
+            $this->service->downloadPluginFromFile($file, 'test-target-plugin');
+            $this->fail('Expected a mismatched update to be rejected.');
+        } catch (Exception $e) {
+            $this->assertSame(
+                trans('admin/plugin.notifications.import_id_mismatch', ['expected' => 'test-target-plugin', 'actual' => 'test-other-plugin']),
+                $e->getMessage()
+            );
+        }
+
+        // The intended plugin is untouched and the archive's plugin was never written.
+        $this->assertSame('1.0.0', $this->installedVersion('test-target-plugin'));
+        $this->assertDirectoryDoesNotExist(plugin_path('test-other-plugin'));
+    }
+
     public function test_import_keeps_the_existing_plugin_when_the_move_fails(): void
     {
         $this->importedPlugins[] = 'test-clean-plugin';

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace App\Tests\Integration\Services;
+
+use App\Services\Helpers\PluginService;
+use App\Tests\Integration\IntegrationTestCase;
+use Exception;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\File;
+use Spatie\TemporaryDirectory\TemporaryDirectory;
+use ZipArchive;
+
+class PluginServiceTest extends IntegrationTestCase
+{
+    private PluginService $service;
+
+    /** @var string[] */
+    private array $importedPlugins = [];
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = $this->app->make(PluginService::class);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up anything the service extracted into the real plugins directory.
+        foreach ($this->importedPlugins as $id) {
+            File::deleteDirectory(plugin_path($id));
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_import_uses_plugin_json_id_not_the_upload_filename(): void
+    {
+        // Zip contains a top-level folder "test-import-plugin", but the upload is renamed as
+        // a browser would on a duplicate download.
+        $file = $this->makeUpload('test-import-plugin(1).zip', [
+            'test-import-plugin/plugin.json' => json_encode(['id' => 'test-import-plugin']),
+        ]);
+
+        $this->importedPlugins[] = 'test-import-plugin';
+
+        $id = $this->service->downloadPluginFromFile($file);
+
+        $this->assertSame('test-import-plugin', $id);
+        $this->assertFileExists(plugin_path('test-import-plugin', 'plugin.json'));
+        // The (1) suffixed folder must never be created.
+        $this->assertDirectoryDoesNotExist(plugin_path('test-import-plugin(1)'));
+    }
+
+    public function test_import_handles_flat_zip_without_a_top_level_folder(): void
+    {
+        $file = $this->makeUpload('renamed(2).zip', [
+            'plugin.json' => json_encode(['id' => 'test-flat-plugin']),
+        ]);
+
+        $this->importedPlugins[] = 'test-flat-plugin';
+
+        $id = $this->service->downloadPluginFromFile($file);
+
+        $this->assertSame('test-flat-plugin', $id);
+        $this->assertFileExists(plugin_path('test-flat-plugin', 'plugin.json'));
+    }
+
+    public function test_import_without_a_manifest_fails_loudly(): void
+    {
+        $file = $this->makeUpload('not-a-plugin.zip', [
+            'readme.txt' => 'nothing to see here',
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_rejects_a_duplicate_plugin(): void
+    {
+        $this->importedPlugins[] = 'test-dupe-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
+            'test-dupe-plugin/plugin.json' => json_encode(['id' => 'test-dupe-plugin']),
+        ]));
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_exists'));
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-dupe-plugin.zip', [
+            'test-dupe-plugin/plugin.json' => json_encode(['id' => 'test-dupe-plugin']),
+        ]));
+    }
+
+    /**
+     * Build a zip on disk from the given [path => contents] map and wrap it in an UploadedFile.
+     *
+     * @param  array<string, string>  $entries
+     */
+    private function makeUpload(string $clientName, array $entries): UploadedFile
+    {
+        $tmpDir = TemporaryDirectory::make();
+        $zipPath = $tmpDir->path('upload.zip');
+
+        $zip = new ZipArchive();
+        $zip->open($zipPath, ZipArchive::CREATE);
+        foreach ($entries as $path => $contents) {
+            $zip->addFromString($path, $contents);
+        }
+        $zip->close();
+
+        // test mode (last arg) bypasses the is_uploaded_file() check.
+        return new UploadedFile($zipPath, $clientName, 'application/zip', null, true);
+    }
+}

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -19,6 +19,9 @@ class PluginServiceTest extends IntegrationTestCase
     /** @var string[] */
     private array $importedPlugins = [];
 
+    /** @var TemporaryDirectory[] */
+    private array $uploadDirs = [];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -37,6 +40,11 @@ class PluginServiceTest extends IntegrationTestCase
 
         foreach (File::glob(plugin_path('.import-*')) as $leftover) {
             File::deleteDirectory($leftover);
+        }
+
+        // TemporaryDirectory::make() does not clean up on its own; remove the upload fixtures.
+        foreach ($this->uploadDirs as $dir) {
+            $dir->delete();
         }
 
         parent::tearDown();
@@ -294,6 +302,7 @@ class PluginServiceTest extends IntegrationTestCase
     private function makeUpload(string $clientName, array $entries): UploadedFile
     {
         $tmpDir = TemporaryDirectory::make();
+        $this->uploadDirs[] = $tmpDir;
         $zipPath = $tmpDir->path('upload.zip');
 
         $zip = new ZipArchive();

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -5,6 +5,7 @@ namespace App\Tests\Integration\Services;
 use App\Services\Helpers\PluginService;
 use App\Tests\Integration\IntegrationTestCase;
 use Exception;
+use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
@@ -76,6 +77,55 @@ class PluginServiceTest extends IntegrationTestCase
         $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
 
         $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_with_a_non_string_id_fails_loudly(): void
+    {
+        $file = $this->makeUpload('bad-id.zip', [
+            'plugin.json' => json_encode(['id' => []]),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_clean_download_keeps_the_existing_plugin_when_the_move_fails(): void
+    {
+        $this->importedPlugins[] = 'test-clean-plugin';
+
+        $this->service->downloadPluginFromFile($this->makeUpload('test-clean-plugin.zip', [
+            'test-clean-plugin/plugin.json' => json_encode(['id' => 'test-clean-plugin', 'version' => '1.0.0']),
+        ]), true);
+
+        // Force the move into plugins/<id> to fail, standing in for any filesystem-level
+        // failure mid-replace. The set-aside and restore moves (to/from the .bak dir) run
+        // for real so we can assert the original install survives.
+        $real = new Filesystem();
+        File::partialMock()
+            ->shouldReceive('moveDirectory')
+            ->andReturnUsing(function ($from, $to) use ($real) {
+                if (str_ends_with($to, '.bak') || str_ends_with($from, '.bak')) {
+                    return $real->moveDirectory($from, $to);
+                }
+
+                return false;
+            });
+
+        $file = $this->makeUpload('test-clean-plugin.zip', [
+            'test-clean-plugin/plugin.json' => json_encode(['id' => 'test-clean-plugin', 'version' => '2.0.0']),
+        ]);
+
+        try {
+            $this->service->downloadPluginFromFile($file, true);
+            $this->fail('Expected the import to fail.');
+        } catch (Exception) {
+            // The original install must still be there after a failed clean download.
+        }
+
+        $this->assertFileExists(plugin_path('test-clean-plugin', 'plugin.json'));
+        $this->assertDirectoryDoesNotExist(plugin_path('test-clean-plugin.bak'));
     }
 
     public function test_import_rejects_a_duplicate_plugin(): void

--- a/tests/Integration/Services/PluginServiceTest.php
+++ b/tests/Integration/Services/PluginServiceTest.php
@@ -8,6 +8,7 @@ use Exception;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
 use PHPUnit\Framework\Attributes\DataProvider;
 use Spatie\TemporaryDirectory\TemporaryDirectory;
 use ZipArchive;
@@ -142,6 +143,77 @@ class PluginServiceTest extends IntegrationTestCase
         $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
 
         $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_with_an_empty_id_fails_loudly(): void
+    {
+        $file = $this->makeUpload('empty-id.zip', [
+            'plugin.json' => json_encode(['id' => '']),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_ignores_a_plugin_json_nested_too_deep(): void
+    {
+        // locatePluginManifest only looks at the root and one level deep; anything deeper is
+        // not treated as a plugin.
+        $file = $this->makeUpload('deep.zip', [
+            'a/b/plugin.json' => $this->manifest('too-deep'),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage(trans('admin/plugin.notifications.import_no_manifest'));
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_rejects_a_zip_with_a_path_traversal_entry(): void
+    {
+        // A malicious archive entry that would write outside the extraction directory must be
+        // rejected before extraction, even if it also carries a valid plugin.json.
+        $file = $this->makeUpload('evil.zip', [
+            '../evil.txt' => 'pwned',
+            'evil/plugin.json' => $this->manifest('evil'),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Zip file contains invalid path traversal sequences.');
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_rejects_a_zip_larger_than_the_configured_max(): void
+    {
+        config()->set('panel.plugin.max_import_size', 10);
+
+        $file = $this->makeUpload('too-big.zip', [
+            'too-big/plugin.json' => $this->manifest('too-big'),
+        ]);
+
+        $this->expectException(Exception::class);
+        $this->expectExceptionMessage('Zip file too large');
+
+        $this->service->downloadPluginFromFile($file);
+    }
+
+    public function test_import_from_url_downloads_and_installs_the_plugin(): void
+    {
+        $this->importedPlugins[] = 'test-url-plugin';
+
+        $bytes = file_get_contents($this->makeUpload('whatever.zip', [
+            'test-url-plugin/plugin.json' => $this->manifest('test-url-plugin'),
+        ])->getPathname());
+
+        Http::fake(['*' => Http::response($bytes)]);
+
+        $id = $this->service->downloadPluginFromUrl('https://example.test/download/test-url-plugin.zip');
+
+        $this->assertSame('test-url-plugin', $id);
+        $this->assertFileExists(plugin_path('test-url-plugin', 'plugin.json'));
     }
 
     /**


### PR DESCRIPTION
Fixes #2486.

Importing a plugin zip whose filename had been renamed (like `modpack-manager(1).zip` after a duplicate download) failed silently. Nothing got imported and there was no error.

The problem was we derived the plugin id from the upload filename. If that name didn't match the folder inside the zip, the extract path was wrong and the import quietly did nothing.

Now we extract to a temp dir first and read the id from the plugin's own `plugin.json`, so the filename doesn't matter. It handles both flat zips and ones with a single top-level folder. If there's no valid `plugin.json`, or the plugin already exists, you get a real error message instead of silence.

### Hardening (from review)

- **Same-volume extraction.** The temp dir now lives on the plugins volume (a dotfile so plugin discovery ignores it) instead of the system temp dir. This makes the move into `plugins/<id>` an atomic same-filesystem rename rather than a cross-device `rename()` that returns `false` on hosts where `/tmp` is a separate mount — the very setups where the import was failing.
- **ID validation.** The manifest `id` is validated as a safe directory slug before it's used as a path, so an `id` like `../../evil` is rejected instead of escaping the plugins directory.
- **Safe rollback.** On a clean re-download the existing install is set aside as a dotfile backup until the new copy is in place; every move is checked and the prior plugin is restored if the swap fails.

### Tests

Integration tests cover the renamed zip, flat zip, missing/invalid/non-string/uppercase ids, id slug guard (path traversal, slash, space, dotfiles), duplicate rejection, temp-dir cleanup, and both the successful and failed clean-replace paths.