### PR TITLE
Add `RedirectIfNotInstalled` middleware to filament panel middleware instead of global

### DIFF
--- a/app/Http/Middleware/RedirectIfNotInstalled.php
+++ b/app/Http/Middleware/RedirectIfNotInstalled.php
@@ -19,6 +19,10 @@ class RedirectIfNotInstalled
             return $next($request);
         }
 
+        if ($request->routeIs('installer')) {
+            return $next($request);
+        }
+
         return redirect()->route('installer');
     }
 }

--- a/app/Providers/Filament/PanelProvider.php
+++ b/app/Providers/Filament/PanelProvider.php
@@ -7,6 +7,7 @@ use App\Filament\Pages\Auth\EditProfile;
 use App\Filament\Pages\Auth\Login;
 use App\Http\Middleware\LanguageMiddleware;
 use App\Http\Middleware\PreventRequestForgery;
+use App\Http\Middleware\RedirectIfNotInstalled;
 use App\Http\Middleware\RequireTwoFactorAuthentication;
 use App\Http\Middleware\SetSecurityHeaders;
 use Filament\Actions\Action;
@@ -72,6 +73,7 @@ abstract class PanelProvider extends BasePanelProvider
                 DispatchServingFilamentEvent::class,
                 LanguageMiddleware::class,
                 SetSecurityHeaders::class,
+                RedirectIfNotInstalled::class,
             ])
             ->authMiddleware([
                 Authenticate::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -13,7 +13,6 @@ use App\Http\Middleware\LanguageMiddleware;
 use App\Http\Middleware\MaintenanceMiddleware;
 use App\Http\Middleware\PreventRequestForgery;
 use App\Http\Middleware\RedirectIfAuthenticated;
-use App\Http\Middleware\RedirectIfNotInstalled;
 use App\Http\Middleware\SetSecurityHeaders;
 use Illuminate\Contracts\Debug\ExceptionHandler;
 use Illuminate\Foundation\Application;
@@ -31,7 +30,6 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->redirectGuestsTo(fn () => route('filament.app.auth.login'));
 
         $middleware->web([
-            RedirectIfNotInstalled::class,
             LanguageMiddleware::class,
             SetSecurityHeaders::class,
         ]);


### PR DESCRIPTION
Fixes the installer redirecting to itself over and over again.