### PR TITLE
Always use `APP_URL` as origin and asset origin

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -52,10 +52,12 @@ class AppServiceProvider extends ServiceProvider
         SoftwareVersionService $versionService,
         Repository $config,
     ): void {
-        // If the APP_URL value is set with https:// make sure we force it here. Theoretically
-        // this should just work with the proxy logic, but there are a lot of cases where it
-        // doesn't, and it triggers a lot of support requests, so lets just head it off here.
-        URL::forceHttps(Str::startsWith(config('app.url') ?? '', 'https://'));
+        $appUrl = config('app.url') ?? '';
+
+        URL::forceHttps(Str::startsWith($appUrl, 'https://'));
+
+        URL::useOrigin($appUrl);
+        URL::useAssetOrigin($appUrl);
 
         if ($app->runningInConsole() && empty(config('app.key'))) {
             $config->set('app.key', '');


### PR DESCRIPTION
This makes sure the `APP_URL` is always used for urls so you don't have to manually set the `ASSET_URL` when behind proxies.