### PR TITLE
feat: allow admins to access suspended servers in client API

### DIFF
--- a/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
+++ b/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
@@ -50,7 +50,7 @@ class AuthenticateServerAccess
             // Still allow users to get information about their server if it is installing or
             // being transferred.
             if (!$request->routeIs('api:client:server.view')) {
-                throw_if(($server->isSuspended() || $server->node->isUnderMaintenance()) && !$request->routeIs('api:client:server.resources'), $exception);
+                throw_if(!$user->isAdmin() && ($server->isSuspended() || $server->node->isUnderMaintenance()) && !$request->routeIs('api:client:server.resources'), $exception);
                 throw_if($user->cannot('update server', $server) || !$request->routeIs($this->except), $exception);
             }
         }

--- a/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
+++ b/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
@@ -50,8 +50,10 @@ class AuthenticateServerAccess
             // Still allow users to get information about their server if it is installing or
             // being transferred.
             if (!$request->routeIs('api:client:server.view')) {
-                throw_if(!$user->isAdmin() && ($server->isSuspended() || $server->node->isUnderMaintenance()) && !$request->routeIs('api:client:server.resources'), $exception);
-                throw_if($user->cannot('update server', $server) || !$request->routeIs($this->except), $exception);
+                $isExcepted = $request->routeIs($this->except) || ($user->isAdmin() && $request->is('api/client/servers/*/files*'));
+
+                throw_if(($server->isSuspended() || $server->node->isUnderMaintenance()) && !$request->routeIs('api:client:server.resources') && !$isExcepted, $exception);
+                throw_if($user->cannot('update server', $server) || !$isExcepted, $exception);
             }
         }
 

--- a/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
+++ b/app/Http/Middleware/Api/Client/Server/AuthenticateServerAccess.php
@@ -18,6 +18,7 @@ class AuthenticateServerAccess
      */
     protected array $except = [
         'api:client:server.ws',
+        'api:client:server.files.*',
     ];
 
     /**
@@ -50,10 +51,7 @@ class AuthenticateServerAccess
             // Still allow users to get information about their server if it is installing or
             // being transferred.
             if (!$request->routeIs('api:client:server.view')) {
-                $isExcepted = $request->routeIs($this->except) || ($user->isAdmin() && $request->is('api/client/servers/*/files*'));
-
-                throw_if(($server->isSuspended() || $server->node->isUnderMaintenance()) && !$request->routeIs('api:client:server.resources') && !$isExcepted, $exception);
-                throw_if($user->cannot('update server', $server) || !$isExcepted, $exception);
+                throw_unless($user->can('update server', $server) && $request->routeIs($this->except), $exception);
             }
         }
 

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -70,21 +70,21 @@ Route::prefix('/servers/{server:uuid}')->middleware([ServerSubject::class, Authe
         Route::delete('/{database}', [Client\Servers\DatabaseController::class, 'delete']);
     });
 
-    Route::prefix('/files')->group(function () {
-        Route::get('/list', [Client\Servers\FileController::class, 'directory']);
-        Route::get('/contents', [Client\Servers\FileController::class, 'contents']);
-        Route::get('/download', [Client\Servers\FileController::class, 'download']);
-        Route::put('/rename', [Client\Servers\FileController::class, 'rename']);
-        Route::post('/copy', [Client\Servers\FileController::class, 'copy']);
-        Route::post('/write', [Client\Servers\FileController::class, 'write']);
-        Route::post('/compress', [Client\Servers\FileController::class, 'compress']);
-        Route::post('/decompress', [Client\Servers\FileController::class, 'decompress']);
-        Route::post('/delete', [Client\Servers\FileController::class, 'delete']);
-        Route::post('/create-folder', [Client\Servers\FileController::class, 'create']);
-        Route::post('/chmod', [Client\Servers\FileController::class, 'chmod']);
+    Route::prefix('/files')->name('api:client:server.files.')->group(function () {
+        Route::get('/list', [Client\Servers\FileController::class, 'directory'])->name('list');
+        Route::get('/contents', [Client\Servers\FileController::class, 'contents'])->name('contents');
+        Route::get('/download', [Client\Servers\FileController::class, 'download'])->name('download');
+        Route::put('/rename', [Client\Servers\FileController::class, 'rename'])->name('rename');
+        Route::post('/copy', [Client\Servers\FileController::class, 'copy'])->name('copy');
+        Route::post('/write', [Client\Servers\FileController::class, 'write'])->name('write');
+        Route::post('/compress', [Client\Servers\FileController::class, 'compress'])->name('compress');
+        Route::post('/decompress', [Client\Servers\FileController::class, 'decompress'])->name('decompress');
+        Route::post('/delete', [Client\Servers\FileController::class, 'delete'])->name('delete');
+        Route::post('/create-folder', [Client\Servers\FileController::class, 'create'])->name('create-folder');
+        Route::post('/chmod', [Client\Servers\FileController::class, 'chmod'])->name('chmod');
         Route::middleware([ResourceLimit::FilePull->middleware()])
-            ->post('/pull', [Client\Servers\FileController::class, 'pull']);
-        Route::get('/upload', Client\Servers\FileUploadController::class);
+            ->post('/pull', [Client\Servers\FileController::class, 'pull'])->name('pull');
+        Route::get('/upload', Client\Servers\FileUploadController::class)->name('upload');
     });
 
     Route::prefix('/schedules')->group(function () {

--- a/tests/Integration/Api/Client/Server/AuthenticateServerAccessTest.php
+++ b/tests/Integration/Api/Client/Server/AuthenticateServerAccessTest.php
@@ -1,0 +1,104 @@
+<?php
+
+namespace App\Tests\Integration\Api\Client\Server;
+
+use App\Enums\ServerState;
+use App\Enums\SubuserPermission;
+use App\Models\Role;
+use App\Models\User;
+use App\Repositories\Daemon\DaemonFileRepository;
+use App\Tests\Integration\Api\Client\ClientApiIntegrationTestCase;
+use Illuminate\Http\Response;
+use Spatie\Permission\Models\Permission;
+
+class AuthenticateServerAccessTest extends ClientApiIntegrationTestCase
+{
+    /**
+     * Test that the owner of a suspended server cannot access its files.
+     */
+    public function test_owner_cannot_access_files_on_suspended_server(): void
+    {
+        [$user, $server] = $this->generateTestAccount();
+        $server->update(['status' => ServerState::Suspended]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid/files/list")
+            ->assertStatus(Response::HTTP_CONFLICT);
+    }
+
+    /**
+     * Test that a subuser with file permissions cannot access files on a suspended server.
+     */
+    public function test_subuser_cannot_access_files_on_suspended_server(): void
+    {
+        [$user, $server] = $this->generateTestAccount([SubuserPermission::FileRead]);
+        $server->update(['status' => ServerState::Suspended]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid/files/list")
+            ->assertStatus(Response::HTTP_CONFLICT);
+    }
+
+    /**
+     * Test that an admin without permission to update the server cannot access files
+     * on a suspended server they have no direct access to.
+     */
+    public function test_admin_without_update_permission_cannot_access_files_on_suspended_server(): void
+    {
+        $server = $this->createServerModel(['status' => ServerState::Suspended]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        $role = Role::findOrCreate('view-only-test', 'web');
+        $role->givePermissionTo(Permission::findOrCreate('view server', 'web'));
+        $user->syncRoles($role);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid/files/list")
+            ->assertStatus(Response::HTTP_NOT_FOUND);
+    }
+
+    /**
+     * Test that a root admin can still list files on a suspended server.
+     */
+    public function test_root_admin_can_access_files_on_suspended_server(): void
+    {
+        $server = $this->createServerModel(['status' => ServerState::Suspended]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        $user->syncRoles(Role::getRootAdmin());
+
+        $repository = \Mockery::mock(DaemonFileRepository::class);
+        $this->app->instance(DaemonFileRepository::class, $repository);
+
+        $repository->expects('setServer')
+            ->with(\Mockery::on(fn ($value) => $server->uuid === $value->uuid))
+            ->andReturnSelf()
+            ->getMock()
+            ->expects('getDirectory')
+            ->with('/')
+            ->andReturn([]);
+
+        $this->actingAs($user)
+            ->getJson("/api/client/servers/$server->uuid/files/list")
+            ->assertOk();
+    }
+
+    /**
+     * Test that the suspended bypass only covers the excepted routes; a root admin
+     * still cannot use other endpoints on a suspended server.
+     */
+    public function test_root_admin_cannot_send_commands_to_suspended_server(): void
+    {
+        $server = $this->createServerModel(['status' => ServerState::Suspended]);
+
+        /** @var User $user */
+        $user = User::factory()->create();
+        $user->syncRoles(Role::getRootAdmin());
+
+        $this->actingAs($user)
+            ->postJson("/api/client/servers/$server->uuid/command", ['command' => 'say Test'])
+            ->assertStatus(Response::HTTP_CONFLICT);
+    }
+}


### PR DESCRIPTION
This allows an admin user to bypass the suspended and maintenance checks in the client API, giving them access to the server's files even when the server is suspended.