### PR TITLE
Passkeys Fix origin not allowed

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -18,12 +18,14 @@ use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Validation\ValidationException;
+use Laravel\Passkeys\Passkeys;
 use PDOException;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\HttpKernel\Exception\HttpException;
 use Symfony\Component\HttpKernel\Exception\HttpExceptionInterface;
 use Symfony\Component\Mailer\Exception\TransportException;
 use Throwable;
+use Webauthn\Exception\AuthenticatorResponseVerificationException;
 
 class Handler extends ExceptionHandler
 {
@@ -39,6 +41,7 @@ class Handler extends ExceptionHandler
      */
     protected $dontReport = [
         AuthenticationException::class,
+        AuthenticatorResponseVerificationException::class,
         AuthorizationException::class,
         HttpException::class,
         ModelNotFoundException::class,
@@ -55,6 +58,7 @@ class Handler extends ExceptionHandler
     protected static array $exceptionResponseCodes = [
         AuthenticationException::class => 401,
         AuthorizationException::class => 403,
+        AuthenticatorResponseVerificationException::class => 422,
         ValidationException::class => 422,
     ];
 
@@ -89,6 +93,37 @@ class Handler extends ExceptionHandler
         $this->reportable(function (TransportException $ex) {
             $ex = $this->generateCleanedExceptionStack($ex);
         });
+
+        $this->renderable(fn (AuthenticatorResponseVerificationException $ex, Request $request) => $this->invalidPasskey($ex, $request));
+    }
+
+    /**
+     * Turn a failed WebAuthn ceremony into an actionable response.
+     *
+     * The library only reports that the browser's origin wasn't accepted, which on its
+     * own is impossible to act on, so log the origin we received alongside the ones the
+     * panel is configured for and tell the user which address passkeys work at.
+     */
+    private function invalidPasskey(AuthenticatorResponseVerificationException $exception, Request $request): JsonResponse
+    {
+        $isOriginFailure = Str::startsWith($exception->getMessage(), ['Invalid origin', 'Invalid scheme']);
+
+        if ($isOriginFailure) {
+            logger()->warning('Passkey rejected: ' . $exception->getMessage(), [
+                'origin' => $request->headers->get('Origin'),
+                'allowed_origins' => Passkeys::allowedOrigins(),
+                'relying_party_id' => Passkeys::relyingPartyId(),
+            ]);
+        }
+
+        $detail = $isOriginFailure
+            ? trans('passkeys.invalid_origin', ['domain' => Passkeys::relyingPartyId()])
+            : trans('passkeys.invalid');
+
+        return new JsonResponse(
+            $this->convertExceptionToArray($exception, ['detail' => $detail]),
+            JsonResponse::HTTP_UNPROCESSABLE_ENTITY,
+        );
     }
 
     private function generateCleanedExceptionStack(Throwable $exception): string

--- a/app/Helpers/PasskeyOrigin.php
+++ b/app/Helpers/PasskeyOrigin.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Helpers;
+
+class PasskeyOrigin
+{
+    /**
+     * Ports that are implicit for a scheme, and therefore never part of an origin.
+     */
+    private const DefaultPorts = [
+        'http' => 80,
+        'https' => 443,
+    ];
+
+    /**
+     * Reduce a URL to the origin browsers report during a WebAuthn ceremony:
+     * "scheme://host[:port]", without any path, query or default port.
+     *
+     * Returns null when the value has no usable host.
+     */
+    public static function normalize(?string $url): ?string
+    {
+        $url = trim((string) $url);
+
+        if ($url === '') {
+            return null;
+        }
+
+        // Bare hosts are assumed to be https, since WebAuthn only runs in secure contexts.
+        if (!str_contains($url, '://')) {
+            $url = 'https://' . $url;
+        }
+
+        $parts = parse_url($url);
+
+        if (!is_array($parts) || !isset($parts['host'])) {
+            return null;
+        }
+
+        $scheme = $parts['scheme'] ?? 'https';
+        $port = $parts['port'] ?? null;
+
+        $origin = $scheme . '://' . $parts['host'];
+
+        if ($port !== null && $port !== (self::DefaultPorts[$scheme] ?? null)) {
+            $origin .= ':' . $port;
+        }
+
+        return $origin;
+    }
+
+    /**
+     * Normalize a list of URLs into a unique list of origins, dropping empty entries.
+     *
+     * @param  array<array-key, string|null>  $urls
+     * @return list<string>
+     */
+    public static function all(array $urls): array
+    {
+        $origins = array_filter(array_map(self::normalize(...), $urls));
+
+        return array_values(array_unique($origins));
+    }
+}

--- a/app/Http/Middleware/AllowPasskeyOrigin.php
+++ b/app/Http/Middleware/AllowPasskeyOrigin.php
@@ -1,0 +1,60 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use App\Helpers\PasskeyOrigin;
+use Closure;
+use Illuminate\Http\Request;
+use Laravel\Passkeys\Passkeys;
+use Symfony\Component\HttpFoundation\Response;
+
+class AllowPasskeyOrigin
+{
+    /**
+     * Hosts browsers treat as a secure context without TLS.
+     */
+    private const LoopbackHosts = ['localhost', '127.0.0.1', '[::1]'];
+
+    /**
+     * Passkeys are bound to a relying party ID (a domain), and the browser refuses to run
+     * a ceremony unless the page it runs on belongs to that domain. The server then checks
+     * the origin a second time against a list built from APP_URL, which rejects requests
+     * the browser considered perfectly valid whenever the two disagree on scheme or port -
+     * a panel reached on a non-standard port, for example.
+     *
+     * Accept the request's own origin when its host is exactly the relying party ID. The
+     * browser has already guaranteed the domain matches, so this gives nothing away, while
+     * an origin on any other domain stays rejected.
+     */
+    public function handle(Request $request, Closure $next): Response
+    {
+        $origin = PasskeyOrigin::normalize($request->headers->get('Origin') ?? $request->getSchemeAndHttpHost());
+
+        if ($origin !== null && $this->belongsToRelyingParty($origin)) {
+            config(['passkeys.allowed_origins' => PasskeyOrigin::all([
+                ...config('passkeys.allowed_origins'),
+                $origin,
+            ])]);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Determine whether an origin is one a browser could have produced for our relying
+     * party: the domain has to be the relying party ID itself, and the page has to have
+     * been a secure context, since that is the only place the WebAuthn API exists.
+     */
+    private function belongsToRelyingParty(string $origin): bool
+    {
+        $parts = parse_url($origin);
+        $host = $parts['host'] ?? null;
+        $scheme = $parts['scheme'] ?? null;
+
+        if ($host !== Passkeys::relyingPartyId()) {
+            return false;
+        }
+
+        return $scheme === 'https' || ($scheme === 'http' && in_array($host, self::LoopbackHosts, true));
+    }
+}

--- a/config/passkeys.php
+++ b/config/passkeys.php
@@ -1,8 +1,31 @@
 <?php
 
+use App\Helpers\PasskeyOrigin;
 use App\Http\Middleware\AddPasskeyErrorMessage;
+use App\Http\Middleware\AllowPasskeyOrigin;
+
+$appOrigin = PasskeyOrigin::normalize(config('app.url')) ?? 'http://localhost';
 
 return [
-    'middleware' => ['web', AddPasskeyErrorMessage::class],
+    /*
+     * Passkeys are bound to this domain. It has to match the host users actually browse
+     * the panel at, otherwise the browser refuses to run the ceremony at all.
+     */
+    'relying_party_id' => env('PASSKEYS_RELYING_PARTY_ID') ?: parse_url($appOrigin, PHP_URL_HOST),
+
+    /*
+     * Only ceremonies completed on one of these origins are accepted. Any origin on the
+     * relying party domain itself is added per request by AllowPasskeyOrigin, so this only
+     * needs entries for hosts that differ from it - subdomains, when the relying party ID
+     * is a parent domain shared by several panels. List those in PASSKEYS_ALLOWED_ORIGINS
+     * as a comma separated list; browsers reject anything outside the relying party domain
+     * before it ever reaches us.
+     */
+    'allowed_origins' => PasskeyOrigin::all(array_merge(
+        [$appOrigin],
+        explode(',', (string) env('PASSKEYS_ALLOWED_ORIGINS')),
+    )),
+
+    'middleware' => ['web', AddPasskeyErrorMessage::class, AllowPasskeyOrigin::class],
     'management_middleware' => ['auth'],
 ];

--- a/lang/en/passkeys.php
+++ b/lang/en/passkeys.php
@@ -6,6 +6,7 @@ return [
     'delete' => 'Delete',
     'error_something_went_wrong_generating_the_passkey' => 'Something went wrong generating the passkey',
     'invalid' => 'Invalid passkey',
+    'invalid_origin' => 'Passkeys are tied to :domain, so they only work when the panel is opened at that address.',
     'last_used' => 'Last used',
     'name' => 'Name',
     'name_placeholder' => 'My passkey',


### PR DESCRIPTION
Fixes passkey logins failing with "Invalid origin. Not in the list of allowed origins." when the panel is reached on a different scheme or port than APP_URL — the origin is now accepted as long as it's on the relying party domain, and a rejected one returns a readable message instead of error without explanation.

Closes https://github.com/pelican-dev/panel/issues/2505