### PR TITLE
Support for concurrent S3 part uploads

### DIFF
--- a/app/Extensions/BackupAdapter/Schemas/S3BackupSchema.php
+++ b/app/Extensions/BackupAdapter/Schemas/S3BackupSchema.php
@@ -141,12 +141,15 @@ final class S3BackupSchema extends BackupAdapterSchema
             )->getUri()->__toString();
         }
 
+        $maxConcurrentUploads = config('backups.max_concurrent_uploads', BackupRemoteUploadController::MAX_CONCURRENT_UPLOADS);
+
         // Set the upload_id on the backup in the database.
         $backup->update(['upload_id' => $params['UploadId']]);
 
         return [
             'parts' => $parts,
             'part_size' => $maxPartSize,
+            'max_concurrent_uploads' => $maxConcurrentUploads
         ];
     }
 

--- a/app/Extensions/BackupAdapter/Schemas/S3BackupSchema.php
+++ b/app/Extensions/BackupAdapter/Schemas/S3BackupSchema.php
@@ -149,7 +149,7 @@ final class S3BackupSchema extends BackupAdapterSchema
         return [
             'parts' => $parts,
             'part_size' => $maxPartSize,
-            'max_concurrent_uploads' => $maxConcurrentUploads
+            'max_concurrent_uploads' => $maxConcurrentUploads,
         ];
     }
 

--- a/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
+++ b/app/Http/Controllers/Api/Remote/Backups/BackupRemoteUploadController.php
@@ -22,6 +22,8 @@ class BackupRemoteUploadController extends Controller
 
     public const MAX_MAX_PART_SIZE = 5 * 1024 * 1024 * 1024; // 5 GiB
 
+    public const MAX_CONCURRENT_UPLOADS = 10;
+
     /**
      * BackupRemoteUploadController constructor.
      */

--- a/config/backups.php
+++ b/config/backups.php
@@ -16,6 +16,14 @@ return [
     // to 6 hours.  To disable this feature, set the value to `0`.
     'prune_age' => (int) env('BACKUP_PRUNE_AGE', 360),
 
+    // This value defines the maximum amount of concurrent requests PER BACKUP for S3 uploads
+    // The default value is 10. 
+    // This value is not guaranteed to be reached (for instance, if there are fewer parts).
+    // If multiple backups are being uploaded to S3 at the same time, each backup may have up to this limit of concurrent uploads.
+    'max_concurrent_uploads' => (int) env('BACKUP_MAX_CONCURRENT_UPLOADS', BackupRemoteUploadController::MAX_CONCURRENT_UPLOADS),
+
+    
+
     // Defines the backup creation throttle limits for users. In this default example, we allow
     // a user to create two (successful or pending) backups per 10 minutes. Even if they delete
     // a backup it will be included in the throttle count.

--- a/config/backups.php
+++ b/config/backups.php
@@ -17,12 +17,10 @@ return [
     'prune_age' => (int) env('BACKUP_PRUNE_AGE', 360),
 
     // This value defines the maximum amount of concurrent requests PER BACKUP for S3 uploads
-    // The default value is 10. 
+    // The default value is 10.
     // This value is not guaranteed to be reached (for instance, if there are fewer parts).
     // If multiple backups are being uploaded to S3 at the same time, each backup may have up to this limit of concurrent uploads.
     'max_concurrent_uploads' => (int) env('BACKUP_MAX_CONCURRENT_UPLOADS', BackupRemoteUploadController::MAX_CONCURRENT_UPLOADS),
-
-    
 
     // Defines the backup creation throttle limits for users. In this default example, we allow
     // a user to create two (successful or pending) backups per 10 minutes. Even if they delete


### PR DESCRIPTION
Currently, when uploading an S3 backup, wings can only upload one part at the time.

Following PR #2504 / issue #2491, S3 backups have been made more reliable and the network overhead has been reduced.

However, a single TCP connection is limited by congestion control (slow start, window scaling) and rarely saturates a fast link on its own. 

S3 supports concurrent uploads. This allows for faster uploads by making full use of the available bandwidth.

This PR simply aims to:
1) Create a `BACKUP_MAX_CONCURRENT_UPLOADS` parameter, set to `10` by default
2) Allow a custom value for this parameter to be set in the .env file
3) Inform Wings of the user’s choice when creating an S3 backup

The default of 10 is based on benchmarks in the Wings PR: most of the throughput gain is already reached at moderate concurrency, and 10 scales well to large backups (hundreds of parts) while keeping connection pressure on the S3 endpoint reasonable. 
If Wings receives no value or an invalid one (e.g. from an older Panel), it falls back to sequential uploads.

The new S3 asynchronous multipart upload logic is located in Wings, in PR pelican-dev/wings#205