### PR TITLE
Rename pelican-dev org references to pelican

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,2 +1,2 @@
-github: pelican-dev
+github: pelican
 custom: [https://hub.pelican.dev/donors]

--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,7 +56,7 @@ body:
   attributes:
     label: Docker Image
     description: The specific Docker image you are using for the game(s) above.
-    placeholder: ghcr.io/pelican-dev/yolks:java_17
+    placeholder: ghcr.io/pelican-eggs/yolks:java_17
 
 - type: textarea
   id: panel-logs
@@ -74,7 +74,7 @@ body:
 - type: checkboxes
   attributes:
     label: Is there an existing issue for this?
-    description: Please [search here](https://github.com/pelican-dev/panel/issues) to see if an issue already exists for your problem.
+    description: Please [search here](https://github.com/pelican/panel/issues) to see if an issue already exists for your problem.
     options:
     - label: I have searched the existing issues before opening this issue.
       required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: true
 contact_links:
   - name: Feature Request
-    url: https://github.com/pelican-dev/panel/discussions
+    url: https://github.com/pelican/panel/discussions
     about: Suggest a new feature or improvement for the software.
   - name: Installation Help
     url: https://pelican.dev/discord

--- a/.github/workflows/cla.yaml
+++ b/.github/workflows/cla.yaml
@@ -23,8 +23,8 @@ jobs:
           PERSONAL_ACCESS_TOKEN: ${{ secrets.CLA_PERSONAL_ACCESS_TOKEN }}
         with:
           path-to-signatures: 'version1/cla.json'
-          path-to-document: 'https://github.com/pelican-dev/panel/blob/main/contributor_license_agreement.md'
+          path-to-document: 'https://github.com/pelican/panel/blob/main/contributor_license_agreement.md'
           branch: 'main'
           allowlist: dependabot[bot]
-          remote-organization-name: pelican-dev
+          remote-organization-name: pelican
           remote-repository-name: cla-signatures

--- a/Dockerfile
+++ b/Dockerfile
@@ -65,7 +65,7 @@ WORKDIR /var/www/html
 RUN apk add --no-cache \
     # packages for running the panel
     caddy ca-certificates supervisor supercronic fcgi \
-    # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
+    # required for installing plugins. Pulled from https://github.com/pelican/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
 # Copy composer binary for runtime plugin dependency management

--- a/Dockerfile.dev
+++ b/Dockerfile.dev
@@ -73,7 +73,7 @@ WORKDIR /var/www/html
 RUN apk add --no-cache \
     # packages for running the panel
     caddy ca-certificates supervisor supercronic fcgi coreutils \
-    # required for installing plugins. Pulled from https://github.com/pelican-dev/panel/pull/2034
+    # required for installing plugins. Pulled from https://github.com/pelican/panel/pull/2034
     zip unzip 7zip bzip2-dev yarn git
 
 # Copy composer binary for runtime plugin dependency management

--- a/app/Filament/Admin/Widgets/CanaryWidget.php
+++ b/app/Filament/Admin/Widgets/CanaryWidget.php
@@ -43,7 +43,7 @@ class CanaryWidget extends FormWidget
                         Action::make('db_issues')
                             ->label(trans('admin/dashboard.sections.intro-developers.button_issues'))
                             ->icon(TablerIcon::BrandGithub)
-                            ->url('https://github.com/pelican-dev/panel/issues', true),
+                            ->url('https://github.com/pelican/panel/issues', true),
                     ]),
             ]);
     }

--- a/app/Services/Helpers/SoftwareVersionService.php
+++ b/app/Services/Helpers/SoftwareVersionService.php
@@ -16,7 +16,7 @@ class SoftwareVersionService
 
         return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
-                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican-dev/panel/releases/latest')->throw()->json();
+                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/panel/releases/latest')->throw()->json();
 
                 return $response['body'];
             } catch (Exception) {
@@ -34,7 +34,7 @@ class SoftwareVersionService
 
         return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
-                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican-dev/panel/releases/latest')->throw()->json();
+                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/panel/releases/latest')->throw()->json();
 
                 return trim($response['tag_name'], 'v');
             } catch (Exception) {
@@ -52,7 +52,7 @@ class SoftwareVersionService
 
         return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
-                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican-dev/wings/releases/latest')->throw()->json();
+                $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/wings/releases/latest')->throw()->json();
 
                 return trim($response['tag_name'], 'v');
             } catch (Exception) {

--- a/bounties.md
+++ b/bounties.md
@@ -1,4 +1,4 @@
-# [Bounties](https://github.com/pelican-dev/panel/issues?q=state%3Aopen%20is%3Aissue%20label%3A%22%F0%9F%92%B0%20fund%22)
+# [Bounties](https://github.com/pelican/panel/issues?q=state%3Aopen%20is%3Aissue%20label%3A%22%F0%9F%92%B0%20fund%22)
 
 Get paid to improve Pelican!
 
@@ -15,6 +15,6 @@ This is still valuable work, so we'll pay out $50 for getting any bounty closed 
 
 ## Issue bounties
 
-We've tagged bounty-eligible issues across openpilot and the rest of our repos; check out all the open ones [here](https://github.com/pelican-dev/panel/issues?q=state%3Aopen%20is%3Aissue%20label%3A%22%F0%9F%92%B0%20fund%22).
+We've tagged bounty-eligible issues across openpilot and the rest of our repos; check out all the open ones [here](https://github.com/pelican/panel/issues?q=state%3Aopen%20is%3Aissue%20label%3A%22%F0%9F%92%B0%20fund%22).
 
 New bounties can be proposed in the [**#feedback**](https://discord.com/channels/1218730176297439332/1218732581797892220) channel in Discord.

--- a/compose-bind.yml
+++ b/compose-bind.yml
@@ -30,7 +30,7 @@ x-common:
 services:
   panel:
     user: "0:0"
-    image: ghcr.io/pelican-dev/panel:latest
+    image: ghcr.io/pelican/panel:latest
     build: .
     restart: unless-stopped
     networks:

--- a/compose-full-stack.yml
+++ b/compose-full-stack.yml
@@ -51,7 +51,7 @@ services:
     restart: always
 
   panel:
-    image: ghcr.io/pelican-dev/panel:latest
+    image: ghcr.io/pelican/panel:latest
     build: .
     restart: unless-stopped
     networks:

--- a/compose.yml
+++ b/compose.yml
@@ -29,7 +29,7 @@ x-common:
 
 services:
   panel:
-    image: ghcr.io/pelican-dev/panel:latest
+    image: ghcr.io/pelican/panel:latest
     build: .
     restart: unless-stopped
     networks:

--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "pelican-dev/panel",
+    "name": "pelican/panel",
     "description": "The free, open-source game management panel. Supporting Minecraft, Spigot, BungeeCord, and SRCDS servers.",
     "license": "AGPL-3.0-only",
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "bf5ed17f08c2f69cb95b0a799e51387d",
+    "content-hash": "6863fc9cc07ac36ae10018f75781f183",
     "packages": [
         {
             "name": "anourvalar/eloquent-serialize",

--- a/contributing.md
+++ b/contributing.md
@@ -52,6 +52,6 @@ Depending on the pull request size this process can take multiple days.
 ## Community and Support
 
 * Help: [Discord](https://discord.gg/pelican-panel)
-* Bugs: [GitHub Issues](https://github.com/pelican-dev/panel/issues)
-* Features: [GitHub Discussions](https://github.com/pelican-dev/panel/discussions)
+* Bugs: [GitHub Issues](https://github.com/pelican/panel/issues)
+* Features: [GitHub Discussions](https://github.com/pelican/panel/discussions)
 * Security vulnerabilities: See our [security policy](./security.md).

--- a/readme.md
+++ b/readme.md
@@ -1,11 +1,11 @@
-<img width="20%" src="https://raw.githubusercontent.com/pelican-dev/panel/main/public/pelican.svg" alt="logo">
+<img width="20%" src="https://raw.githubusercontent.com/pelican/panel/main/public/pelican.svg" alt="logo">
 
 # Pelican Panel
 
 **Fly High, Game On: Pelican's pledge for unrivaled game servers.**
 
-![Total Downloads](https://img.shields.io/github/downloads/pelican-dev/panel/total?style=flat&label=Total%20Downloads&labelColor=rgba(0%2C%2070%2C%20114%2C%201)&color=rgba(255%2C%20255%2C%20255%2C%201)) 
-![Latest Release](https://img.shields.io/github/v/release/pelican-dev/panel?style=flat&label=Latest%20Release&labelColor=rgba(0%2C%2070%2C%20114%2C%201)&color=rgba(255%2C%20255%2C%20255%2C%201))  
+![Total Downloads](https://img.shields.io/github/downloads/pelican/panel/total?style=flat&label=Total%20Downloads&labelColor=rgba(0%2C%2070%2C%20114%2C%201)&color=rgba(255%2C%20255%2C%20255%2C%201)) 
+![Latest Release](https://img.shields.io/github/v/release/pelican/panel?style=flat&label=Latest%20Release&labelColor=rgba(0%2C%2070%2C%20114%2C%201)&color=rgba(255%2C%20255%2C%20255%2C%201))  
 
 Pelican Panel is a free, open-source game server control panel built for communities, hosts, and self-hosters.
 It gives users a modern web UI for creating and managing game servers while running each server in an isolated Docker container through Wings.
@@ -22,9 +22,9 @@ Use Pelican if you want:
 
 * [Read the documentation](https://pelican.dev/docs)
 * [Join the Discord](https://discord.gg/pelican-panel)
-* [Wings](https://github.com/pelican-dev/wings)
-* [Open a GitHub Discussion for general project questions](https://github.com/pelican-dev/panel/discussions)
-* [Open an Issue for confirmed bugs](https://github.com/pelican-dev/panel/issues)
+* [Wings](https://github.com/pelican/wings)
+* [Open a GitHub Discussion for general project questions](https://github.com/pelican/panel/discussions)
+* [Open an Issue for confirmed bugs](https://github.com/pelican/panel/issues)
 
 ## Supported Games and Servers
 
@@ -65,7 +65,7 @@ Good places to start:
 Pelican is built and maintained by volunteers. If Pelican helps you or your community, consider supporting ongoing development:
 
 - [Sponsor the project](https://hub.pelican.dev/sponsor)
-- [Contribute code or documentation](https://github.com/pelican-dev/panel)
+- [Contribute code or documentation](https://github.com/pelican/panel)
 - [Help answer questions in Discord](https://discord.com/channels/1218730176297439332/1219038617133912084)
 - Share Pelican with other server owners
 

--- a/security.md
+++ b/security.md
@@ -3,13 +3,13 @@
 ## Supported Versions
 
 While Pelican is in beta, we only provide security fixes for the most recent beta release. Older beta releases are unsupported.  
-![](https://img.shields.io/github/v/release/pelican-dev/panel?label=latest-release)
+![](https://img.shields.io/github/v/release/pelican/panel?label=latest-release)
 
 ## Reporting a Vulnerability
 
 Please report any vulnerabilities via _one_ of the following methods:
 
-- [Create a security advisory on GitHub](https://github.com/pelican-dev/panel/security/advisories/new)
+- [Create a security advisory on GitHub](https://github.com/pelican/panel/security/advisories/new)
 - Send an e-mail to <team@pelican.dev>
 
 Include steps to reproduce, affected versions, impact, and a proof of concept if available.

--- a/tests/Feature/SettingsControllerTest.php
+++ b/tests/Feature/SettingsControllerTest.php
@@ -82,7 +82,7 @@ test('unauthorized user cannot change docker image in use by server', function (
 
     $this->actingAs($user)
         ->put("/api/client/servers/$server->uuid/settings/docker-image", [
-            'docker_image' => 'ghcr.io/pelican-dev/yolks:java_21',
+            'docker_image' => 'ghcr.io/pelican-eggs/yolks:java_21',
         ])
         ->assertStatus(Response::HTTP_FORBIDDEN);
 

--- a/tests/Unit/Console/Commands/Egg/egg-plcnv3-example.yaml
+++ b/tests/Unit/Console/Commands/Egg/egg-plcnv3-example.yaml
@@ -1,7 +1,7 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v3
-  update_url: 'https://raw.githubusercontent.com/pelican-dev/panel/refs/heads/main/tests/Unit/Console/Command/Egg/egg-ptdlv2.yaml'
+  update_url: 'https://raw.githubusercontent.com/pelican/panel/refs/heads/main/tests/Unit/Console/Command/Egg/egg-ptdlv2.yaml'
 exported_at: '2026-06-01T01:02:03+00:00'
 name: 'Egg Example'
 author: example@example.com

--- a/tests/Unit/Console/Commands/Egg/egg-ptdlv2.json
+++ b/tests/Unit/Console/Commands/Egg/egg-ptdlv2.json
@@ -2,7 +2,7 @@
     "_comment": "DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL",
     "meta": {
         "version": "PTDL_v2",
-        "update_url": "https://raw.githubusercontent.com/pelican-dev/panel/refs/heads/main/tests/Unit/Console/Command/Egg/egg-ptdlv2.json"
+        "update_url": "https://raw.githubusercontent.com/pelican/panel/refs/heads/main/tests/Unit/Console/Command/Egg/egg-ptdlv2.json"
     },
     "exported_at": "2026-06-01T01:02:03+00:00",
     "name": "Egg Example",

--- a/tests/_fixtures/egg-bungeecord.yaml
+++ b/tests/_fixtures/egg-bungeecord.yaml
@@ -1,7 +1,7 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v3
-  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-bungeecord.yaml'
+  update_url: 'https://github.com/pelican/panel/raw/main/database/Seeders/eggs/minecraft/egg-bungeecord.yaml'
 exported_at: '2025-12-28T12:14:41+00:00'
 name: Bungeecord
 author: panel@example.com

--- a/tests/_fixtures/egg-vanilla-minecraft.yaml
+++ b/tests/_fixtures/egg-vanilla-minecraft.yaml
@@ -1,7 +1,7 @@
 _comment: 'DO NOT EDIT: FILE GENERATED AUTOMATICALLY BY PANEL'
 meta:
   version: PLCN_v3
-  update_url: 'https://github.com/pelican-dev/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml'
+  update_url: 'https://github.com/pelican/panel/raw/main/database/Seeders/eggs/minecraft/egg-vanilla-minecraft.yaml'
 exported_at: '2025-10-31T12:35:33+00:00'
 name: 'Vanilla Minecraft'
 author: panel@example.com


### PR DESCRIPTION
**Do not merge this yet.** Holding it as a draft until the org move is finished, since the new paths don't resolve before then. Staging it now so the switch is a merge rather than a scramble.

Most of this is links and image references, but there are a few things in here that are behaviour rather than cosmetics and are worth a look.

`SoftwareVersionService` hits `api.github.com/repos/pelican-dev/{panel,wings}/releases/latest` for the update and version checks, and if that ever stops returning anything the version banners just go blank without anything obviously erroring, which is the annoying kind of failure. Same category of thing: the egg `update_url`s in the test fixtures, the compose files pulling `ghcr.io/pelican-dev/panel:latest`, and the CLA workflow's `remote-organization-name`, which decides where signatures actually get written.

`composer.json` changes the package name to `pelican/panel`, which also shifts `composer.lock`'s content hash, so that's updated too. It's a one-line change in the lock and no dependency versions moved. This one needs the Packagist side renamed to match or the package stops auto-updating.

While I was in here I also fixed the two `ghcr.io/pelican-dev/yolks` references, in the bug report template and in `SettingsControllerTest`. That image never existed under our org, it's a pre-existing typo unrelated to anything else in this PR, and every other yolks reference in this repo already uses `ghcr.io/pelican-eggs/yolks`, so I made those two match. They deliberately do not become `ghcr.io/pelican/yolks`, because that wouldn't exist either.

Two things I deliberately left alone: the Crowdin links in `contributing.md` and `EditProfile.php` still say `crowdin.com/project/pelican-dev`, because Crowdin is a separate service with its own project slug and changing the link before renaming the project over there would just break a link that currently works. If we do rename the Crowdin project we can flip those in a follow-up.

Follow-up work that a PR can't cover: rename the Packagist package, republish the panel image under `ghcr.io/pelican/panel`, move the GitHub Sponsors profile so the FUNDING.yml handle resolves, and fix the repo description and homepage fields in settings.
