### PR TITLE
Point the yolks references at the image that actually exists

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -56,7 +56,7 @@ body:
   attributes:
     label: Docker Image
     description: The specific Docker image you are using for the game(s) above.
-    placeholder: ghcr.io/pelican-dev/yolks:java_17
+    placeholder: ghcr.io/pelican-eggs/yolks:java_17
 
 - type: textarea
   id: panel-logs

--- a/tests/Feature/SettingsControllerTest.php
+++ b/tests/Feature/SettingsControllerTest.php
@@ -82,7 +82,7 @@ test('unauthorized user cannot change docker image in use by server', function (
 
     $this->actingAs($user)
         ->put("/api/client/servers/$server->uuid/settings/docker-image", [
-            'docker_image' => 'ghcr.io/pelican-dev/yolks:java_21',
+            'docker_image' => 'ghcr.io/pelican-eggs/yolks:java_21',
         ])
         ->assertStatus(Response::HTTP_FORBIDDEN);
 


### PR DESCRIPTION
Two lines, pulled out of #2515 so they don't have to wait on anything.

`ghcr.io/pelican-dev/yolks` has never been a real package, it 404s if you go looking for it, so the placeholder in the bug report template and the `docker_image` value in `SettingsControllerTest` were both pointing at nothing. Every other yolks reference in the repo already uses `ghcr.io/pelican-eggs/yolks`, so these two are just brought back in line with the rest.

Nothing to do with anything else going on, it's a typo that's been sitting there, and it's safe to merge whenever.
