### PR TITLE
Use Allocation create permission for creating allocations during server creation

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/CreateServer.php
@@ -245,7 +245,7 @@ class CreateServer extends CreateRecord
                                 ->where('node_id', $get('node_id'))
                                 ->whereNull('server_id'),
                         )
-                        ->createOptionAction(fn (Action $action) => $action->authorize(fn (Get $get) => user()?->can('create', Node::find($get('node_id')))))
+                        ->createOptionAction(fn (Action $action) => $action->authorize(fn () => user()?->can('create', Allocation::class)))
                         ->createOptionForm(function (Get $get) {
                             $getPage = $get;
 


### PR DESCRIPTION
The "create allocation" button in the server creation form required the Node
create permission, while everywhere else allocations are created it checks the
Allocation create permission. Changed it to use the Allocation policy, so users
with allocation permissions can create allocations during server creation.

Fixes #2517