### PR TITLE
Replace the Fractal transformers with laravel-data wire objects

### DIFF
--- a/app/Data/Api/ApiResource.php
+++ b/app/Data/Api/ApiResource.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Data\Api;
+
+use Carbon\CarbonImmutable;
+use Carbon\CarbonInterface;
+use Spatie\LaravelData\Data;
+
+/**
+ * Base class for the API wire format objects that replaced the Fractal transformers.
+ * Concrete classes are plain property bags hydrated by a static fromModel method,
+ * which the envelope layer invokes through the container so extra typed parameters
+ * receive dependency injection. Includes are declared as closures so the envelope
+ * can resolve them lazily with the request context.
+ */
+abstract class ApiResource extends Data
+{
+    public const RESPONSE_TIMEZONE = 'UTC';
+
+    /**
+     * Include names a request may ask for on this resource. Only names listed here
+     * are honored from the query string; unknown names are silently ignored.
+     *
+     * @var string[]
+     */
+    public static array $availableIncludes = [];
+
+    /**
+     * Includes that always run, whether requested or not.
+     *
+     * @var string[]
+     */
+    public static array $defaultIncludes = [];
+
+    /**
+     * The value of the envelope's object key for this resource.
+     */
+    abstract public static function getResourceName(): string;
+
+    /**
+     * Map of include name to resolver. Each resolver receives the model being
+     * transformed and an IncludeContext already descended to that include's path,
+     * and returns an envelope fragment (item, list, or null_resource).
+     *
+     * @return array<string, \Closure(mixed, IncludeContext): array<mixed>>
+     */
+    public static function includes(): array
+    {
+        return [];
+    }
+
+    /**
+     * Return an ISO-8601 formatted timestamp to use in the API response.
+     */
+    protected static function formatTimestamp(string $timestamp): string
+    {
+        return CarbonImmutable::createFromFormat(CarbonInterface::DEFAULT_TO_STRING_FORMAT, $timestamp)
+            ->setTimezone(self::RESPONSE_TIMEZONE)
+            ->toAtomString();
+    }
+}

--- a/app/Data/Api/Application/AllocationData.php
+++ b/app/Data/Api/Application/AllocationData.php
@@ -8,7 +8,7 @@ use App\Models\Allocation;
 use App\Models\Node;
 use App\Models\Server;
 
-class AllocationData extends ApiResource
+final class AllocationData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['node', 'server'];

--- a/app/Data/Api/Application/AllocationData.php
+++ b/app/Data/Api/Application/AllocationData.php
@@ -29,7 +29,7 @@ final class AllocationData extends ApiResource
 
     public static function fromModel(Allocation $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             ip: $model->ip,
             alias: $model->ip_alias,

--- a/app/Data/Api/Application/AllocationData.php
+++ b/app/Data/Api/Application/AllocationData.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Allocation;
+use App\Models\Node;
+use App\Models\Server;
+
+class AllocationData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['node', 'server'];
+
+    public function __construct(
+        public int $id,
+        public string $ip,
+        public ?string $alias,
+        public int $port,
+        public ?string $notes,
+        public bool $assigned,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Allocation::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Allocation $model): static
+    {
+        return new static(
+            id: $model->id,
+            ip: $model->ip,
+            alias: $model->ip_alias,
+            port: $model->port,
+            notes: $model->notes,
+            assigned: !is_null($model->server_id),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'node' => function (Allocation $allocation, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Node::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                return $context->item($allocation->node, NodeData::class);
+            },
+            'server' => function (Allocation $allocation, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME) || !$allocation->server) {
+                    return $context->null();
+                }
+
+                return $context->item($allocation->server, ServerData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/DatabaseHostData.php
+++ b/app/Data/Api/Application/DatabaseHostData.php
@@ -1,0 +1,70 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Database;
+use App\Models\DatabaseHost;
+use App\Models\Node;
+
+class DatabaseHostData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = [
+        'databases',
+        'nodes',
+    ];
+
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $host,
+        public int $port,
+        public string $username,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return DatabaseHost::RESOURCE_NAME;
+    }
+
+    public static function fromModel(DatabaseHost $model): static
+    {
+        return new static(
+            id: $model->id,
+            name: $model->name,
+            host: $model->host,
+            port: $model->port,
+            username: $model->username,
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'databases' => function (DatabaseHost $host, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Database::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $host->loadMissing('databases');
+
+                return $context->collection($host->getRelation('databases'), ServerDatabaseData::class);
+            },
+            'nodes' => function (DatabaseHost $host, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Node::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $host->loadMissing('nodes');
+
+                return $context->collection($host->getRelation('nodes'), NodeData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/DatabaseHostData.php
+++ b/app/Data/Api/Application/DatabaseHostData.php
@@ -8,7 +8,7 @@ use App\Models\Database;
 use App\Models\DatabaseHost;
 use App\Models\Node;
 
-class DatabaseHostData extends ApiResource
+final class DatabaseHostData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = [

--- a/app/Data/Api/Application/DatabaseHostData.php
+++ b/app/Data/Api/Application/DatabaseHostData.php
@@ -33,7 +33,7 @@ final class DatabaseHostData extends ApiResource
 
     public static function fromModel(DatabaseHost $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             name: $model->name,
             host: $model->host,

--- a/app/Data/Api/Application/EggData.php
+++ b/app/Data/Api/Application/EggData.php
@@ -53,7 +53,7 @@ final class EggData extends ApiResource
 
         $model->loadMissing('scriptFrom');
 
-        return new static(
+        return new self(
             id: $model->id,
             uuid: $model->uuid,
             name: $model->name,
@@ -81,8 +81,8 @@ final class EggData extends ApiResource
                 'container' => $model->copy_script_container,
                 'extends' => $model->copy_script_from,
             ],
-            created_at: static::formatTimestamp($model->created_at),
-            updated_at: static::formatTimestamp($model->updated_at),
+            created_at: self::formatTimestamp($model->created_at),
+            updated_at: self::formatTimestamp($model->updated_at),
         );
     }
 

--- a/app/Data/Api/Application/EggData.php
+++ b/app/Data/Api/Application/EggData.php
@@ -9,7 +9,7 @@ use App\Models\EggVariable;
 use App\Models\Server;
 use Illuminate\Support\Arr;
 
-class EggData extends ApiResource
+final class EggData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = [

--- a/app/Data/Api/Application/EggData.php
+++ b/app/Data/Api/Application/EggData.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Egg;
+use App\Models\EggVariable;
+use App\Models\Server;
+use Illuminate\Support\Arr;
+
+class EggData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = [
+        'servers',
+        'variables',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $config
+     * @param  array<string, mixed>  $script
+     */
+    public function __construct(
+        public int $id,
+        public string $uuid,
+        public string $name,
+        public ?string $author,
+        public ?string $description,
+        public ?string $icon,
+        public mixed $features,
+        public mixed $tags,
+        public string $docker_image,
+        public mixed $docker_images,
+        public array $config,
+        public string $startup,
+        public mixed $startup_commands,
+        public array $script,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Egg::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Egg $model): static
+    {
+        $model->loadMissing('configFrom');
+
+        $files = json_decode($model->inherit_config_files ?: '{}', true, 512, JSON_THROW_ON_ERROR);
+
+        $model->loadMissing('scriptFrom');
+
+        return new static(
+            id: $model->id,
+            uuid: $model->uuid,
+            name: $model->name,
+            author: $model->author,
+            description: $model->description,
+            icon: $model->icon,
+            features: $model->features,
+            tags: $model->tags,
+            docker_image: Arr::first($model->docker_images, default: ''), // deprecated, use docker_images
+            docker_images: $model->docker_images,
+            config: [
+                'files' => $files,
+                'startup' => json_decode($model->inherit_config_startup ?: '{}', true),
+                'stop' => $model->inherit_config_stop,
+                'logs' => json_decode($model->inherit_config_logs ?: '{}', true),
+                'file_denylist' => $model->inherit_file_denylist,
+                'extends' => $model->config_from,
+            ],
+            startup: Arr::first($model->startup_commands, default: ''), // deprecated, use startup_commands
+            startup_commands: $model->startup_commands,
+            script: [
+                'privileged' => $model->script_is_privileged,
+                'install' => $model->copy_script_install,
+                'entry' => $model->copy_script_entry,
+                'container' => $model->copy_script_container,
+                'extends' => $model->copy_script_from,
+            ],
+            created_at: static::formatTimestamp($model->created_at),
+            updated_at: static::formatTimestamp($model->updated_at),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'servers' => function (Egg $egg, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $egg->loadMissing('servers');
+
+                return $context->collection($egg->getRelation('servers'), ServerData::class);
+            },
+            'variables' => function (Egg $egg, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Egg::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $egg->loadMissing('variables');
+
+                return $context->collection($egg->getRelation('variables'), EggVariableData::class, EggVariable::RESOURCE_NAME);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/EggVariableData.php
+++ b/app/Data/Api/Application/EggVariableData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use App\Models\Egg;
 use App\Models\EggVariable;
 
-class EggVariableData extends ApiResource
+final class EggVariableData extends ApiResource
 {
     /**
      * @param  array<string, mixed>  $attributes

--- a/app/Data/Api/Application/EggVariableData.php
+++ b/app/Data/Api/Application/EggVariableData.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Models\Egg;
+use App\Models\EggVariable;
+
+class EggVariableData extends ApiResource
+{
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(public array $attributes) {}
+
+    public static function getResourceName(): string
+    {
+        return Egg::RESOURCE_NAME;
+    }
+
+    public static function fromModel(EggVariable $model): static
+    {
+        return new static($model->toArray());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/app/Data/Api/Application/EggVariableData.php
+++ b/app/Data/Api/Application/EggVariableData.php
@@ -20,7 +20,7 @@ final class EggVariableData extends ApiResource
 
     public static function fromModel(EggVariable $model): static
     {
-        return new static($model->toArray());
+        return new self($model->toArray());
     }
 
     /**

--- a/app/Data/Api/Application/MountData.php
+++ b/app/Data/Api/Application/MountData.php
@@ -9,7 +9,7 @@ use App\Models\Mount;
 use App\Models\Node;
 use App\Models\Server;
 
-class MountData extends ApiResource
+final class MountData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['eggs', 'nodes', 'servers'];

--- a/app/Data/Api/Application/MountData.php
+++ b/app/Data/Api/Application/MountData.php
@@ -26,7 +26,7 @@ final class MountData extends ApiResource
 
     public static function fromModel(Mount $model): static
     {
-        return new static($model->toArray());
+        return new self($model->toArray());
     }
 
     /**

--- a/app/Data/Api/Application/MountData.php
+++ b/app/Data/Api/Application/MountData.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Egg;
+use App\Models\Mount;
+use App\Models\Node;
+use App\Models\Server;
+
+class MountData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['eggs', 'nodes', 'servers'];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(public array $attributes) {}
+
+    public static function getResourceName(): string
+    {
+        return Mount::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Mount $model): static
+    {
+        return new static($model->toArray());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'eggs' => function (Mount $mount, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Egg::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $mount->loadMissing('eggs');
+
+                return $context->collection($mount->getRelation('eggs'), EggData::class);
+            },
+            'nodes' => function (Mount $mount, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Node::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $mount->loadMissing('nodes');
+
+                return $context->collection($mount->getRelation('nodes'), NodeData::class);
+            },
+            'servers' => function (Mount $mount, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $mount->loadMissing('servers');
+
+                return $context->collection($mount->getRelation('servers'), ServerData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/NodeData.php
+++ b/app/Data/Api/Application/NodeData.php
@@ -8,7 +8,7 @@ use App\Models\Allocation;
 use App\Models\Node;
 use App\Models\Server;
 
-class NodeData extends ApiResource
+final class NodeData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['allocations', 'servers'];

--- a/app/Data/Api/Application/NodeData.php
+++ b/app/Data/Api/Application/NodeData.php
@@ -29,8 +29,8 @@ final class NodeData extends ApiResource
             ->mapWithKeys(fn ($value, $key) => [snake_case($key) => $value])
             ->toArray();
 
-        $attributes[$model->getUpdatedAtColumn()] = static::formatTimestamp($model->updated_at);
-        $attributes[$model->getCreatedAtColumn()] = static::formatTimestamp($model->created_at);
+        $attributes[$model->getUpdatedAtColumn()] = self::formatTimestamp($model->updated_at);
+        $attributes[$model->getCreatedAtColumn()] = self::formatTimestamp($model->created_at);
 
         $resources = $model->servers()->select(['memory', 'disk', 'cpu'])->get();
 
@@ -40,7 +40,7 @@ final class NodeData extends ApiResource
             'cpu' => $resources->sum('cpu'),
         ];
 
-        return new static($attributes);
+        return new self($attributes);
     }
 
     /**

--- a/app/Data/Api/Application/NodeData.php
+++ b/app/Data/Api/Application/NodeData.php
@@ -1,0 +1,77 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Allocation;
+use App\Models\Node;
+use App\Models\Server;
+
+class NodeData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['allocations', 'servers'];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(public array $attributes) {}
+
+    public static function getResourceName(): string
+    {
+        return Node::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Node $model): static
+    {
+        $attributes = collect($model->toArray())
+            ->mapWithKeys(fn ($value, $key) => [snake_case($key) => $value])
+            ->toArray();
+
+        $attributes[$model->getUpdatedAtColumn()] = static::formatTimestamp($model->updated_at);
+        $attributes[$model->getCreatedAtColumn()] = static::formatTimestamp($model->created_at);
+
+        $resources = $model->servers()->select(['memory', 'disk', 'cpu'])->get();
+
+        $attributes['allocated_resources'] = [
+            'memory' => $resources->sum('memory'),
+            'disk' => $resources->sum('disk'),
+            'cpu' => $resources->sum('cpu'),
+        ];
+
+        return new static($attributes);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'allocations' => function (Node $node, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Allocation::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $node->loadMissing('allocations');
+
+                return $context->collection($node->getRelation('allocations'), AllocationData::class);
+            },
+            'servers' => function (Node $node, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $node->loadMissing('servers');
+
+                return $context->collection($node->getRelation('servers'), ServerData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/PluginData.php
+++ b/app/Data/Api/Application/PluginData.php
@@ -5,10 +5,11 @@ namespace App\Data\Api\Application;
 use App\Data\Api\ApiResource;
 use App\Models\Plugin;
 
-class PluginData extends ApiResource
+final class PluginData extends ApiResource
 {
     /**
      * @param  array<string, mixed>  $meta
+     * @param  string[]|null  $panels
      */
     public function __construct(
         public string $id,

--- a/app/Data/Api/Application/PluginData.php
+++ b/app/Data/Api/Application/PluginData.php
@@ -35,7 +35,7 @@ final class PluginData extends ApiResource
 
     public static function fromModel(Plugin $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             name: $model->name,
             author: $model->author,

--- a/app/Data/Api/Application/PluginData.php
+++ b/app/Data/Api/Application/PluginData.php
@@ -1,0 +1,62 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Models\Plugin;
+
+class PluginData extends ApiResource
+{
+    /**
+     * @param  array<string, mixed>  $meta
+     */
+    public function __construct(
+        public string $id,
+        public string $name,
+        public string $author,
+        public string $version,
+        public ?string $description,
+        public mixed $category,
+        public ?string $url,
+        public ?string $update_url,
+        public string $namespace,
+        public string $class,
+        public ?array $panels,
+        public ?string $panel_version,
+        public mixed $composer_packages,
+        public array $meta,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Plugin::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Plugin $model): static
+    {
+        return new static(
+            id: $model->id,
+            name: $model->name,
+            author: $model->author,
+            version: $model->version,
+            description: $model->description,
+            category: $model->category,
+            url: $model->url,
+            update_url: $model->update_url,
+            namespace: $model->namespace,
+            class: $model->class,
+            panels: $model->panels ? explode(',', $model->panels) : null,
+            panel_version: $model->panel_version,
+            composer_packages: $model->composer_packages ? json_decode($model->composer_packages, true, 512, JSON_THROW_ON_ERROR) : null,
+            meta: [
+                'status' => $model->status,
+                'status_message' => $model->status_message,
+                'load_order' => $model->load_order,
+                'is_compatible' => $model->isCompatible(),
+                'update_available' => $model->isUpdateAvailable(),
+                'can_enable' => $model->canEnable(),
+                'can_disable' => $model->canDisable(),
+            ],
+        );
+    }
+}

--- a/app/Data/Api/Application/RoleData.php
+++ b/app/Data/Api/Application/RoleData.php
@@ -25,7 +25,7 @@ final class RoleData extends ApiResource
 
     public static function fromModel(Role $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             name: $model->name,
             created_at: $model->created_at->toAtomString(),

--- a/app/Data/Api/Application/RoleData.php
+++ b/app/Data/Api/Application/RoleData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use App\Data\Api\IncludeContext;
 use App\Models\Role;
 
-class RoleData extends ApiResource
+final class RoleData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['permissions'];

--- a/app/Data/Api/Application/RoleData.php
+++ b/app/Data/Api/Application/RoleData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Role;
+
+class RoleData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['permissions'];
+
+    public function __construct(
+        public int $id,
+        public string $name,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Role::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Role $model): static
+    {
+        return new static(
+            id: $model->id,
+            name: $model->name,
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'permissions' => function (Role $role, IncludeContext $context): array {
+                $role->loadMissing('permissions');
+
+                return $context->collection($role->getRelation('permissions'), RolePermissionData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/RolePermissionData.php
+++ b/app/Data/Api/Application/RolePermissionData.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use Spatie\Permission\Models\Permission;
+
+class RolePermissionData extends ApiResource
+{
+    public function __construct(
+        public string $name,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return 'permissions';
+    }
+
+    public static function fromModel(Permission $model): static
+    {
+        return new static(
+            name: $model->name,
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+}

--- a/app/Data/Api/Application/RolePermissionData.php
+++ b/app/Data/Api/Application/RolePermissionData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Application;
 use App\Data\Api\ApiResource;
 use Spatie\Permission\Models\Permission;
 
-class RolePermissionData extends ApiResource
+final class RolePermissionData extends ApiResource
 {
     public function __construct(
         public string $name,

--- a/app/Data/Api/Application/RolePermissionData.php
+++ b/app/Data/Api/Application/RolePermissionData.php
@@ -20,7 +20,7 @@ final class RolePermissionData extends ApiResource
 
     public static function fromModel(Permission $model): static
     {
-        return new static(
+        return new self(
             name: $model->name,
             created_at: $model->created_at->toAtomString(),
             updated_at: $model->updated_at->toAtomString(),

--- a/app/Data/Api/Application/ServerData.php
+++ b/app/Data/Api/Application/ServerData.php
@@ -57,7 +57,7 @@ final class ServerData extends ApiResource
 
     public static function fromModel(Server $model, EnvironmentService $environmentService): static
     {
-        return new static(
+        return new self(
             id: $model->getKey(),
             external_id: $model->external_id,
             uuid: $model->uuid,
@@ -94,8 +94,8 @@ final class ServerData extends ApiResource
                 'installed' => $model->isInstalled() ? 1 : 0,
                 'environment' => $environmentService->handle($model),
             ],
-            updated_at: static::formatTimestamp($model->updated_at),
-            created_at: static::formatTimestamp($model->created_at),
+            updated_at: self::formatTimestamp($model->updated_at),
+            created_at: self::formatTimestamp($model->created_at),
         );
     }
 

--- a/app/Data/Api/Application/ServerData.php
+++ b/app/Data/Api/Application/ServerData.php
@@ -12,7 +12,7 @@ use App\Models\Server;
 use App\Models\User;
 use App\Services\Servers\EnvironmentService;
 
-class ServerData extends ApiResource
+final class ServerData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = [

--- a/app/Data/Api/Application/ServerData.php
+++ b/app/Data/Api/Application/ServerData.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Allocation;
+use App\Models\Database;
+use App\Models\Egg;
+use App\Models\Node;
+use App\Models\Server;
+use App\Models\User;
+use App\Services\Servers\EnvironmentService;
+
+class ServerData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = [
+        'allocations',
+        'user',
+        'subusers',
+        'egg',
+        'variables',
+        'node',
+        'databases',
+    ];
+
+    /**
+     * @param  array<string, mixed>  $limits
+     * @param  array<string, mixed>  $feature_limits
+     * @param  array<string, mixed>  $container
+     */
+    public function __construct(
+        public int $id,
+        public ?string $external_id,
+        public string $uuid,
+        public string $identifier,
+        public string $name,
+        public ?string $description,
+        public mixed $status,
+        public bool $suspended,
+        public array $limits,
+        public array $feature_limits,
+        public int $user,
+        public int $node,
+        public ?int $allocation,
+        public int $egg,
+        public array $container,
+        public string $updated_at,
+        public string $created_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Server::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Server $model, EnvironmentService $environmentService): static
+    {
+        return new static(
+            id: $model->getKey(),
+            external_id: $model->external_id,
+            uuid: $model->uuid,
+            identifier: $model->uuid_short,
+            name: $model->name,
+            description: $model->description,
+            status: $model->status,
+            // This field is deprecated, please use "status".
+            suspended: $model->isSuspended(),
+            limits: [
+                'memory' => $model->memory,
+                'swap' => $model->swap,
+                'disk' => $model->disk,
+                'io' => $model->io,
+                'cpu' => $model->cpu,
+                'threads' => $model->threads,
+                // This field is deprecated, please use "oom_killer".
+                'oom_disabled' => !$model->oom_killer,
+                'oom_killer' => $model->oom_killer,
+            ],
+            feature_limits: [
+                'databases' => $model->database_limit,
+                'allocations' => $model->allocation_limit,
+                'backups' => $model->backup_limit,
+            ],
+            user: $model->owner_id,
+            node: $model->node_id,
+            allocation: $model->allocation_id,
+            egg: $model->egg_id,
+            container: [
+                'startup_command' => $model->startup,
+                'image' => $model->image,
+                // This field is deprecated, please use "status".
+                'installed' => $model->isInstalled() ? 1 : 0,
+                'environment' => $environmentService->handle($model),
+            ],
+            updated_at: static::formatTimestamp($model->updated_at),
+            created_at: static::formatTimestamp($model->created_at),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'allocations' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Allocation::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('allocations');
+
+                return $context->collection($server->getRelation('allocations'), AllocationData::class);
+            },
+            'user' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(User::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('user');
+
+                return $context->item($server->getRelation('user'), UserData::class);
+            },
+            'subusers' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(User::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('subusers');
+
+                return $context->collection($server->getRelation('subusers'), SubuserData::class, 'subuser');
+            },
+            'egg' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Egg::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('egg');
+
+                return $context->item($server->getRelation('egg'), EggData::class);
+            },
+            'variables' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('variables');
+
+                return $context->collection($server->getRelation('variables'), ServerVariableData::class, 'server_variable');
+            },
+            'node' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Node::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('node');
+
+                return $context->item($server->getRelation('node'), NodeData::class);
+            },
+            'databases' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Database::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $server->loadMissing('databases');
+
+                return $context->collection($server->getRelation('databases'), ServerDatabaseData::class, 'databases');
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/ServerDatabaseData.php
+++ b/app/Data/Api/Application/ServerDatabaseData.php
@@ -31,7 +31,7 @@ final class ServerDatabaseData extends ApiResource
 
     public static function fromModel(Database $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             server: $model->server_id,
             host: $model->database_host_id,

--- a/app/Data/Api/Application/ServerDatabaseData.php
+++ b/app/Data/Api/Application/ServerDatabaseData.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Database;
+use App\Models\DatabaseHost;
+
+class ServerDatabaseData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['password', 'host'];
+
+    public function __construct(
+        public int $id,
+        public int $server,
+        public int $host,
+        public string $database,
+        public string $username,
+        public string $remote,
+        public ?int $max_connections,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Database::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Database $model): static
+    {
+        return new static(
+            id: $model->id,
+            server: $model->server_id,
+            host: $model->database_host_id,
+            database: $model->database,
+            username: $model->username,
+            remote: $model->remote,
+            max_connections: $model->max_connections,
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'password' => function (Database $database, IncludeContext $context): array {
+                return $context->rawItem([
+                    'password' => $database->password,
+                ], 'database_password');
+            },
+            'host' => function (Database $database, IncludeContext $context): array {
+                if (!$context->allowsAdmin(DatabaseHost::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $database->loadMissing('host');
+
+                return $context->item($database->getRelation('host'), DatabaseHostData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/ServerDatabaseData.php
+++ b/app/Data/Api/Application/ServerDatabaseData.php
@@ -7,7 +7,7 @@ use App\Data\Api\IncludeContext;
 use App\Models\Database;
 use App\Models\DatabaseHost;
 
-class ServerDatabaseData extends ApiResource
+final class ServerDatabaseData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['password', 'host'];

--- a/app/Data/Api/Application/ServerVariableData.php
+++ b/app/Data/Api/Application/ServerVariableData.php
@@ -7,7 +7,7 @@ use App\Data\Api\IncludeContext;
 use App\Models\Egg;
 use App\Models\EggVariable;
 
-class ServerVariableData extends ApiResource
+final class ServerVariableData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['parent'];

--- a/app/Data/Api/Application/ServerVariableData.php
+++ b/app/Data/Api/Application/ServerVariableData.php
@@ -24,7 +24,7 @@ final class ServerVariableData extends ApiResource
 
     public static function fromModel(EggVariable $model): static
     {
-        return new static($model->toArray());
+        return new self($model->toArray());
     }
 
     /**

--- a/app/Data/Api/Application/ServerVariableData.php
+++ b/app/Data/Api/Application/ServerVariableData.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Egg;
+use App\Models\EggVariable;
+
+class ServerVariableData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['parent'];
+
+    /**
+     * @param  array<string, mixed>  $attributes
+     */
+    public function __construct(public array $attributes) {}
+
+    public static function getResourceName(): string
+    {
+        return EggVariable::RESOURCE_NAME;
+    }
+
+    public static function fromModel(EggVariable $model): static
+    {
+        return new static($model->toArray());
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return $this->attributes;
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'parent' => function (EggVariable $variable, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Egg::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $variable->loadMissing('variable');
+
+                return $context->item($variable->getRelation('variable'), EggVariableData::class, 'variable');
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/SubuserData.php
+++ b/app/Data/Api/Application/SubuserData.php
@@ -8,7 +8,7 @@ use App\Models\Server;
 use App\Models\Subuser;
 use App\Models\User;
 
-class SubuserData extends ApiResource
+final class SubuserData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['user', 'server'];

--- a/app/Data/Api/Application/SubuserData.php
+++ b/app/Data/Api/Application/SubuserData.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Server;
+use App\Models\Subuser;
+use App\Models\User;
+
+class SubuserData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['user', 'server'];
+
+    public function __construct(
+        public int $id,
+        public int $user_id,
+        public int $server_id,
+        public mixed $permissions,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Subuser::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Subuser $model): static
+    {
+        return new static(
+            id: $model->id,
+            user_id: $model->user_id,
+            server_id: $model->server_id,
+            permissions: $model->permissions,
+            created_at: static::formatTimestamp($model->created_at),
+            updated_at: static::formatTimestamp($model->updated_at),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'user' => function (Subuser $subuser, IncludeContext $context): array {
+                if (!$context->allowsAdmin(User::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $subuser->loadMissing('user');
+
+                return $context->item($subuser->getRelation('user'), UserData::class);
+            },
+            'server' => function (Subuser $subuser, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $subuser->loadMissing('server');
+
+                return $context->item($subuser->getRelation('server'), ServerData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/SubuserData.php
+++ b/app/Data/Api/Application/SubuserData.php
@@ -29,13 +29,13 @@ final class SubuserData extends ApiResource
 
     public static function fromModel(Subuser $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             user_id: $model->user_id,
             server_id: $model->server_id,
             permissions: $model->permissions,
-            created_at: static::formatTimestamp($model->created_at),
-            updated_at: static::formatTimestamp($model->updated_at),
+            created_at: self::formatTimestamp($model->created_at),
+            updated_at: self::formatTimestamp($model->updated_at),
         );
     }
 

--- a/app/Data/Api/Application/UserData.php
+++ b/app/Data/Api/Application/UserData.php
@@ -1,0 +1,83 @@
+<?php
+
+namespace App\Data\Api\Application;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Role;
+use App\Models\Server;
+use App\Models\User;
+use Spatie\LaravelData\Attributes\MapOutputName;
+
+class UserData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = [
+        'servers',
+        'roles',
+    ];
+
+    public function __construct(
+        public int $id,
+        public ?string $external_id,
+        public bool $is_managed_externally,
+        public string $uuid,
+        public string $username,
+        public string $email,
+        public ?string $language,
+        public bool $root_admin,
+        #[MapOutputName('2fa_enabled')]
+        public bool $twoFactorEnabled,
+        #[MapOutputName('2fa')]
+        public bool $twoFactorLegacy,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return User::RESOURCE_NAME;
+    }
+
+    public static function fromModel(User $model): static
+    {
+        return new static(
+            id: $model->id,
+            external_id: $model->external_id,
+            is_managed_externally: $model->is_managed_externally,
+            uuid: $model->uuid,
+            username: $model->username,
+            email: $model->email,
+            language: $model->language,
+            root_admin: $model->isRootAdmin(),
+            twoFactorEnabled: filled($model->mfa_app_secret),
+            twoFactorLegacy: filled($model->mfa_app_secret), // deprecated, use "2fa_enabled"
+            created_at: static::formatTimestamp($model->created_at),
+            updated_at: static::formatTimestamp($model->updated_at),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'servers' => function (User $user, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Server::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $user->loadMissing('servers');
+
+                return $context->collection($user->getRelation('servers'), ServerData::class);
+            },
+            'roles' => function (User $user, IncludeContext $context): array {
+                if (!$context->allowsAdmin(Role::RESOURCE_NAME)) {
+                    return $context->null();
+                }
+
+                $user->loadMissing('roles');
+
+                return $context->collection($user->getRelation('roles'), RoleData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Application/UserData.php
+++ b/app/Data/Api/Application/UserData.php
@@ -41,7 +41,7 @@ final class UserData extends ApiResource
 
     public static function fromModel(User $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             external_id: $model->external_id,
             is_managed_externally: $model->is_managed_externally,
@@ -52,8 +52,8 @@ final class UserData extends ApiResource
             root_admin: $model->isRootAdmin(),
             twoFactorEnabled: filled($model->mfa_app_secret),
             twoFactorLegacy: filled($model->mfa_app_secret), // deprecated, use "2fa_enabled"
-            created_at: static::formatTimestamp($model->created_at),
-            updated_at: static::formatTimestamp($model->updated_at),
+            created_at: self::formatTimestamp($model->created_at),
+            updated_at: self::formatTimestamp($model->updated_at),
         );
     }
 

--- a/app/Data/Api/Application/UserData.php
+++ b/app/Data/Api/Application/UserData.php
@@ -9,7 +9,7 @@ use App\Models\Server;
 use App\Models\User;
 use Spatie\LaravelData\Attributes\MapOutputName;
 
-class UserData extends ApiResource
+final class UserData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = [

--- a/app/Data/Api/Client/ActivityLogData.php
+++ b/app/Data/Api/Client/ActivityLogData.php
@@ -8,7 +8,7 @@ use App\Models\ActivityLog;
 use App\Models\User;
 use Illuminate\Http\Request;
 
-class ActivityLogData extends ApiResource
+final class ActivityLogData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['actor'];

--- a/app/Data/Api/Client/ActivityLogData.php
+++ b/app/Data/Api/Client/ActivityLogData.php
@@ -38,7 +38,7 @@ final class ActivityLogData extends ApiResource
         // the actor that performed the action or because they are an administrator.
         $canViewIp = $model->actor?->is($request->user()) || $request->user()->can('seeIps activityLog');
 
-        return new static(
+        return new self(
             // This is not for security, it is only to provide a unique identifier to
             // the front-end for each entry to improve rendering performance since there
             // is nothing else sufficiently unique to key off at this point.

--- a/app/Data/Api/Client/ActivityLogData.php
+++ b/app/Data/Api/Client/ActivityLogData.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\ActivityLog;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+class ActivityLogData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['actor'];
+
+    /**
+     * @param  array<string, mixed>  $properties
+     */
+    public function __construct(
+        public string $id,
+        public string $event,
+        public bool $is_api,
+        public ?string $ip,
+        public ?string $description,
+        public array $properties,
+        public bool $has_additional_metadata,
+        public string $timestamp,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return ActivityLog::RESOURCE_NAME;
+    }
+
+    public static function fromModel(ActivityLog $model, Request $request): static
+    {
+        // Whether the user can view the IP address in the output, either because they are
+        // the actor that performed the action or because they are an administrator.
+        $canViewIp = $model->actor?->is($request->user()) || $request->user()->can('seeIps activityLog');
+
+        return new static(
+            // This is not for security, it is only to provide a unique identifier to
+            // the front-end for each entry to improve rendering performance since there
+            // is nothing else sufficiently unique to key off at this point.
+            id: sha1((string) $model->id),
+            event: $model->event,
+            is_api: !is_null($model->api_key_id),
+            ip: $canViewIp ? $model->ip : null,
+            description: $model->description,
+            properties: $model->wrapProperties(),
+            has_additional_metadata: $model->hasAdditionalMetadata(),
+            timestamp: $model->timestamp->toAtomString(),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'actor' => function (ActivityLog $model, IncludeContext $context): array {
+                if (!$model->actor instanceof User) {
+                    return $context->null();
+                }
+
+                return $context->item($model->actor, UserData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Client/AllocationData.php
+++ b/app/Data/Api/Client/AllocationData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\Allocation;
 
-class AllocationData extends ApiResource
+final class AllocationData extends ApiResource
 {
     public function __construct(
         public int $id,

--- a/app/Data/Api/Client/AllocationData.php
+++ b/app/Data/Api/Client/AllocationData.php
@@ -23,7 +23,7 @@ final class AllocationData extends ApiResource
 
     public static function fromModel(Allocation $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             ip: $model->ip,
             ip_alias: $model->ip_alias,

--- a/app/Data/Api/Client/AllocationData.php
+++ b/app/Data/Api/Client/AllocationData.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\Allocation;
+
+class AllocationData extends ApiResource
+{
+    public function __construct(
+        public int $id,
+        public string $ip,
+        public ?string $ip_alias,
+        public int $port,
+        public ?string $notes,
+        public bool $is_default,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Allocation::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Allocation $model): static
+    {
+        return new static(
+            id: $model->id,
+            ip: $model->ip,
+            ip_alias: $model->ip_alias,
+            port: $model->port,
+            notes: $model->notes,
+            is_default: $model->server->allocation_id === $model->id,
+        );
+    }
+}

--- a/app/Data/Api/Client/ApiKeyData.php
+++ b/app/Data/Api/Client/ApiKeyData.php
@@ -25,7 +25,7 @@ final class ApiKeyData extends ApiResource
 
     public static function fromModel(ApiKey $model): static
     {
-        return new static(
+        return new self(
             identifier: $model->identifier,
             description: $model->memo,
             allowed_ips: $model->allowed_ips,

--- a/app/Data/Api/Client/ApiKeyData.php
+++ b/app/Data/Api/Client/ApiKeyData.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\ApiKey;
+
+class ApiKeyData extends ApiResource
+{
+    /**
+     * @param  string[]  $allowed_ips
+     */
+    public function __construct(
+        public string $identifier,
+        public ?string $description,
+        public array $allowed_ips,
+        public ?string $last_used_at,
+        public string $created_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return ApiKey::RESOURCE_NAME;
+    }
+
+    public static function fromModel(ApiKey $model): static
+    {
+        return new static(
+            identifier: $model->identifier,
+            description: $model->memo,
+            allowed_ips: $model->allowed_ips,
+            last_used_at: $model->last_used_at ? $model->last_used_at->toAtomString() : null,
+            created_at: $model->created_at->toAtomString(),
+        );
+    }
+}

--- a/app/Data/Api/Client/ApiKeyData.php
+++ b/app/Data/Api/Client/ApiKeyData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\ApiKey;
 
-class ApiKeyData extends ApiResource
+final class ApiKeyData extends ApiResource
 {
     /**
      * @param  string[]  $allowed_ips

--- a/app/Data/Api/Client/BackupData.php
+++ b/app/Data/Api/Client/BackupData.php
@@ -30,7 +30,7 @@ final class BackupData extends ApiResource
 
     public static function fromModel(Backup $model): static
     {
-        return new static(
+        return new self(
             uuid: $model->uuid,
             is_successful: $model->is_successful,
             is_locked: $model->is_locked,

--- a/app/Data/Api/Client/BackupData.php
+++ b/app/Data/Api/Client/BackupData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\Backup;
 
-class BackupData extends ApiResource
+final class BackupData extends ApiResource
 {
     /**
      * @param  string[]  $ignored_files

--- a/app/Data/Api/Client/BackupData.php
+++ b/app/Data/Api/Client/BackupData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\Backup;
+
+class BackupData extends ApiResource
+{
+    /**
+     * @param  string[]  $ignored_files
+     */
+    public function __construct(
+        public string $uuid,
+        public bool $is_successful,
+        public bool $is_locked,
+        public bool $is_scheduled,
+        public string $name,
+        public array $ignored_files,
+        public ?string $checksum,
+        public int $bytes,
+        public string $created_at,
+        public ?string $completed_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Backup::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Backup $model): static
+    {
+        return new static(
+            uuid: $model->uuid,
+            is_successful: $model->is_successful,
+            is_locked: $model->is_locked,
+            is_scheduled: $model->is_scheduled,
+            name: $model->name,
+            ignored_files: $model->ignored_files,
+            checksum: $model->checksum,
+            bytes: $model->bytes,
+            created_at: $model->created_at->toAtomString(),
+            completed_at: $model->completed_at ? $model->completed_at->toAtomString() : null,
+        );
+    }
+}

--- a/app/Data/Api/Client/DatabaseData.php
+++ b/app/Data/Api/Client/DatabaseData.php
@@ -33,7 +33,7 @@ final class DatabaseData extends ApiResource
     {
         $model->loadMissing('host');
 
-        return new static(
+        return new self(
             id: $model->id,
             host: [
                 'address' => $model->getRelation('host')->host,

--- a/app/Data/Api/Client/DatabaseData.php
+++ b/app/Data/Api/Client/DatabaseData.php
@@ -7,7 +7,7 @@ use App\Data\Api\IncludeContext;
 use App\Enums\SubuserPermission;
 use App\Models\Database;
 
-class DatabaseData extends ApiResource
+final class DatabaseData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['password'];

--- a/app/Data/Api/Client/DatabaseData.php
+++ b/app/Data/Api/Client/DatabaseData.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Enums\SubuserPermission;
+use App\Models\Database;
+
+class DatabaseData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['password'];
+
+    /**
+     * @param  array{address: string, port: int}  $host
+     */
+    public function __construct(
+        public int $id,
+        public array $host,
+        public string $name,
+        public string $username,
+        public ?string $connections_from,
+        public ?int $max_connections,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Database::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Database $model): static
+    {
+        $model->loadMissing('host');
+
+        return new static(
+            id: $model->id,
+            host: [
+                'address' => $model->getRelation('host')->host,
+                'port' => $model->getRelation('host')->port,
+            ],
+            name: $model->database,
+            username: $model->username,
+            connections_from: $model->remote,
+            max_connections: $model->max_connections,
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'password' => function (Database $database, IncludeContext $context): array {
+                if (!$context->allowsClient(SubuserPermission::DatabaseViewPassword->value, $database->server)) {
+                    return $context->null();
+                }
+
+                return $context->rawItem([
+                    'password' => $database->password,
+                ], 'database_password');
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Client/EggData.php
+++ b/app/Data/Api/Client/EggData.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\Egg;
+
+class EggData extends ApiResource
+{
+    public function __construct(
+        public string $uuid,
+        public string $name,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Egg::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Egg $model): static
+    {
+        return new static(
+            uuid: $model->uuid,
+            name: $model->name,
+        );
+    }
+}

--- a/app/Data/Api/Client/EggData.php
+++ b/app/Data/Api/Client/EggData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\Egg;
 
-class EggData extends ApiResource
+final class EggData extends ApiResource
 {
     public function __construct(
         public string $uuid,

--- a/app/Data/Api/Client/EggData.php
+++ b/app/Data/Api/Client/EggData.php
@@ -19,7 +19,7 @@ final class EggData extends ApiResource
 
     public static function fromModel(Egg $model): static
     {
-        return new static(
+        return new self(
             uuid: $model->uuid,
             name: $model->name,
         );

--- a/app/Data/Api/Client/EggVariableData.php
+++ b/app/Data/Api/Client/EggVariableData.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\EggVariable;
+use BadMethodCallException;
+
+class EggVariableData extends ApiResource
+{
+    public function __construct(
+        public string $name,
+        public ?string $description,
+        public string $env_variable,
+        public ?string $default_value,
+        public ?string $server_value,
+        public bool $is_editable,
+        public string $rules,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return EggVariable::RESOURCE_NAME;
+    }
+
+    public static function fromModel(EggVariable $model): static
+    {
+        // This guards against someone incorrectly retrieving variables (haha, me) and then passing
+        // them into the transformer and along to the user. Just throw an exception and break the entire
+        // pathway since you should never be exposing these types of variables to a client.
+        throw_unless($model->user_viewable, new BadMethodCallException('Cannot transform a hidden egg variable in a client transformer.'));
+
+        return new static(
+            name: $model->name,
+            description: $model->description,
+            env_variable: $model->env_variable,
+            default_value: $model->default_value,
+            server_value: $model->server_value,
+            is_editable: $model->user_editable,
+            rules: implode('|', $model->rules),
+        );
+    }
+}

--- a/app/Data/Api/Client/EggVariableData.php
+++ b/app/Data/Api/Client/EggVariableData.php
@@ -30,7 +30,7 @@ final class EggVariableData extends ApiResource
         // pathway since you should never be exposing these types of variables to a client.
         throw_unless($model->user_viewable, new BadMethodCallException('Cannot transform a hidden egg variable in a client transformer.'));
 
-        return new static(
+        return new self(
             name: $model->name,
             description: $model->description,
             env_variable: $model->env_variable,

--- a/app/Data/Api/Client/EggVariableData.php
+++ b/app/Data/Api/Client/EggVariableData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use App\Models\EggVariable;
 use BadMethodCallException;
 
-class EggVariableData extends ApiResource
+final class EggVariableData extends ApiResource
 {
     public function __construct(
         public string $name,

--- a/app/Data/Api/Client/FileObjectData.php
+++ b/app/Data/Api/Client/FileObjectData.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Carbon;
+
+class FileObjectData extends ApiResource
+{
+    public function __construct(
+        public ?string $name,
+        public ?string $mode,
+        public mixed $mode_bits,
+        public ?int $size,
+        public bool $is_file,
+        public bool $is_symlink,
+        public string $mimetype,
+        public string $created_at,
+        public string $modified_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return 'file_object';
+    }
+
+    /**
+     * @param  array<string, mixed>  $model
+     */
+    public static function fromModel(array $model): static
+    {
+        return new static(
+            name: Arr::get($model, 'name'),
+            mode: Arr::get($model, 'mode'),
+            mode_bits: Arr::get($model, 'mode_bits'),
+            size: Arr::get($model, 'size'),
+            is_file: Arr::get($model, 'file', true),
+            is_symlink: Arr::get($model, 'symlink', false),
+            mimetype: Arr::get($model, 'mime', 'application/octet-stream'),
+            created_at: Carbon::parse(Arr::get($model, 'created', ''))->toAtomString(),
+            modified_at: Carbon::parse(Arr::get($model, 'modified', ''))->toAtomString(),
+        );
+    }
+}

--- a/app/Data/Api/Client/FileObjectData.php
+++ b/app/Data/Api/Client/FileObjectData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 
-class FileObjectData extends ApiResource
+final class FileObjectData extends ApiResource
 {
     public function __construct(
         public ?string $name,

--- a/app/Data/Api/Client/FileObjectData.php
+++ b/app/Data/Api/Client/FileObjectData.php
@@ -30,7 +30,7 @@ final class FileObjectData extends ApiResource
      */
     public static function fromModel(array $model): static
     {
-        return new static(
+        return new self(
             name: Arr::get($model, 'name'),
             mode: Arr::get($model, 'mode'),
             mode_bits: Arr::get($model, 'mode_bits'),

--- a/app/Data/Api/Client/ScheduleData.php
+++ b/app/Data/Api/Client/ScheduleData.php
@@ -37,7 +37,7 @@ final class ScheduleData extends ApiResource
 
     public static function fromModel(Schedule $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             name: $model->name,
             cron: [

--- a/app/Data/Api/Client/ScheduleData.php
+++ b/app/Data/Api/Client/ScheduleData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use App\Data\Api\IncludeContext;
 use App\Models\Schedule;
 
-class ScheduleData extends ApiResource
+final class ScheduleData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['tasks'];

--- a/app/Data/Api/Client/ScheduleData.php
+++ b/app/Data/Api/Client/ScheduleData.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Models\Schedule;
+
+class ScheduleData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['tasks'];
+
+    /** @var string[] */
+    public static array $defaultIncludes = ['tasks'];
+
+    /**
+     * @param  array{day_of_week: string, day_of_month: string, month: string, hour: string, minute: string}  $cron
+     */
+    public function __construct(
+        public int $id,
+        public string $name,
+        public array $cron,
+        public bool $is_active,
+        public bool $is_processing,
+        public bool $only_when_online,
+        public ?string $last_run_at,
+        public ?string $next_run_at,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Schedule::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Schedule $model): static
+    {
+        return new static(
+            id: $model->id,
+            name: $model->name,
+            cron: [
+                'day_of_week' => $model->cron_day_of_week,
+                'day_of_month' => $model->cron_day_of_month,
+                'month' => $model->cron_month,
+                'hour' => $model->cron_hour,
+                'minute' => $model->cron_minute,
+            ],
+            is_active: $model->is_active,
+            is_processing: $model->is_processing,
+            only_when_online: $model->only_when_online,
+            last_run_at: $model->last_run_at?->toAtomString(),
+            next_run_at: $model->next_run_at?->toAtomString(),
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            'tasks' => function (Schedule $model, IncludeContext $context): array {
+                return $context->collection($model->tasks, TaskData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Client/ServerData.php
+++ b/app/Data/Api/Client/ServerData.php
@@ -11,7 +11,7 @@ use App\Services\Servers\StartupCommandService;
 use Illuminate\Http\Request;
 use Spatie\LaravelData\Optional;
 
-class ServerData extends ApiResource
+final class ServerData extends ApiResource
 {
     /** @var string[] */
     public static array $availableIncludes = ['egg', 'subusers'];

--- a/app/Data/Api/Client/ServerData.php
+++ b/app/Data/Api/Client/ServerData.php
@@ -55,7 +55,7 @@ final class ServerData extends ApiResource
     {
         $user = $request->user();
 
-        return new static(
+        return new self(
             server_owner: $user->id === $model->owner_id,
             identifier: $model->uuid_short,
             internal_id: $model->id,

--- a/app/Data/Api/Client/ServerData.php
+++ b/app/Data/Api/Client/ServerData.php
@@ -1,0 +1,136 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Data\Api\IncludeContext;
+use App\Enums\ServerState;
+use App\Enums\SubuserPermission;
+use App\Models\Server;
+use App\Services\Servers\StartupCommandService;
+use Illuminate\Http\Request;
+use Spatie\LaravelData\Optional;
+
+class ServerData extends ApiResource
+{
+    /** @var string[] */
+    public static array $availableIncludes = ['egg', 'subusers'];
+
+    /** @var string[] */
+    public static array $defaultIncludes = ['allocations', 'variables'];
+
+    /**
+     * @param  array{ip: string, alias: string|null, port: int}  $sftp_details
+     * @param  array<string, mixed>  $limits
+     * @param  string[]|null  $egg_features
+     * @param  array<string, int|null>  $feature_limits
+     */
+    public function __construct(
+        public bool $server_owner,
+        public string $identifier,
+        public int $internal_id,
+        public string $uuid,
+        public string $name,
+        public string $node,
+        public bool $is_node_under_maintenance,
+        public array $sftp_details,
+        public string|null|Optional $description,
+        public array $limits,
+        public string $invocation,
+        public string $docker_image,
+        public ?array $egg_features,
+        public array $feature_limits,
+        public ?ServerState $status,
+        public bool $is_suspended,
+        public bool $is_installing,
+        public bool $is_transferring,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Server::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Server $model, StartupCommandService $service, Request $request): static
+    {
+        $user = $request->user();
+
+        return new static(
+            server_owner: $user->id === $model->owner_id,
+            identifier: $model->uuid_short,
+            internal_id: $model->id,
+            uuid: $model->uuid,
+            name: $model->name,
+            node: $model->node->name,
+            is_node_under_maintenance: $model->node->isUnderMaintenance(),
+            sftp_details: [
+                'ip' => $model->node->fqdn,
+                'alias' => $model->node->daemon_sftp_alias,
+                'port' => $model->node->daemon_sftp,
+            ],
+            description: config('panel.editable_server_descriptions') ? $model->description : Optional::create(),
+            limits: [
+                'memory' => $model->memory,
+                'swap' => $model->swap,
+                'disk' => $model->disk,
+                'io' => $model->io,
+                'cpu' => $model->cpu,
+                'threads' => $model->threads,
+                // This field is deprecated, please use "oom_killer".
+                'oom_disabled' => !$model->oom_killer,
+                'oom_killer' => $model->oom_killer,
+            ],
+            invocation: $service->handle($model, hideAllValues: !$user->can(SubuserPermission::StartupRead, $model)),
+            docker_image: $model->image,
+            egg_features: $model->egg->inherit_features,
+            feature_limits: [
+                'databases' => $model->database_limit,
+                'allocations' => $model->allocation_limit,
+                'backups' => $model->backup_limit,
+            ],
+            status: $model->status,
+            // This field is deprecated, please use "status".
+            is_suspended: $model->isSuspended(),
+            // This field is deprecated, please use "status".
+            is_installing: !$model->isInstalled(),
+            is_transferring: !is_null($model->transfer),
+        );
+    }
+
+    public static function includes(): array
+    {
+        return [
+            // If the user doesn't have read permissions for the allocations we only return
+            // the primary server allocation, and any notes associated with it are hidden.
+            // This avoids permission regression without hiding information the frontend
+            // needs to make sense when browsing or searching results.
+            'allocations' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsClient(SubuserPermission::AllocationRead->value, $server)) {
+                    $primary = clone $server->allocation;
+                    $primary->notes = null;
+
+                    return $context->collection([$primary], AllocationData::class);
+                }
+
+                return $context->collection($server->allocations, AllocationData::class);
+            },
+            'variables' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsClient(SubuserPermission::StartupRead->value, $server)) {
+                    return $context->null();
+                }
+
+                return $context->collection($server->variables->where('user_viewable', true), EggVariableData::class);
+            },
+            'egg' => function (Server $server, IncludeContext $context): array {
+                return $context->item($server->egg, EggData::class);
+            },
+            'subusers' => function (Server $server, IncludeContext $context): array {
+                if (!$context->allowsClient(SubuserPermission::UserRead->value, $server)) {
+                    return $context->null();
+                }
+
+                return $context->collection($server->subusers, SubuserData::class);
+            },
+        ];
+    }
+}

--- a/app/Data/Api/Client/StatsData.php
+++ b/app/Data/Api/Client/StatsData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use Illuminate\Support\Arr;
 
-class StatsData extends ApiResource
+final class StatsData extends ApiResource
 {
     /**
      * @param  array<string, int|float>  $resources

--- a/app/Data/Api/Client/StatsData.php
+++ b/app/Data/Api/Client/StatsData.php
@@ -26,7 +26,7 @@ final class StatsData extends ApiResource
      */
     public static function fromModel(array $model): static
     {
-        return new static(
+        return new self(
             current_state: Arr::get($model, 'state', 'stopped'),
             is_suspended: Arr::get($model, 'is_suspended', false),
             resources: [

--- a/app/Data/Api/Client/StatsData.php
+++ b/app/Data/Api/Client/StatsData.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use Illuminate\Support\Arr;
+
+class StatsData extends ApiResource
+{
+    /**
+     * @param  array<string, int|float>  $resources
+     */
+    public function __construct(
+        public string $current_state,
+        public bool $is_suspended,
+        public array $resources,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return 'stats';
+    }
+
+    /**
+     * @param  array<string, mixed>  $model
+     */
+    public static function fromModel(array $model): static
+    {
+        return new static(
+            current_state: Arr::get($model, 'state', 'stopped'),
+            is_suspended: Arr::get($model, 'is_suspended', false),
+            resources: [
+                'memory_bytes' => Arr::get($model, 'utilization.memory_bytes', 0),
+                'cpu_absolute' => Arr::get($model, 'utilization.cpu_absolute', 0),
+                'disk_bytes' => Arr::get($model, 'utilization.disk_bytes', 0),
+                'network_rx_bytes' => Arr::get($model, 'utilization.network.rx_bytes', 0),
+                'network_tx_bytes' => Arr::get($model, 'utilization.network.tx_bytes', 0),
+                'uptime' => Arr::get($model, 'utilization.uptime', 0),
+            ],
+        );
+    }
+}

--- a/app/Data/Api/Client/SubuserData.php
+++ b/app/Data/Api/Client/SubuserData.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\Subuser;
+use Spatie\LaravelData\Attributes\MapOutputName;
+
+class SubuserData extends ApiResource
+{
+    /**
+     * @param  string[]  $permissions
+     */
+    public function __construct(
+        public string $uuid,
+        public string $username,
+        public string $email,
+        public ?string $language,
+        public string $image,
+        public bool $admin,
+        public bool $root_admin,
+        #[MapOutputName('2fa_enabled')]
+        public bool $two_factor_enabled,
+        public string $created_at,
+        public string $updated_at,
+        public array $permissions,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Subuser::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Subuser $model): static
+    {
+        $user = UserData::fromModel($model->user);
+
+        return new static(
+            uuid: $user->uuid,
+            username: $user->username,
+            email: $user->email,
+            language: $user->language,
+            image: $user->image,
+            admin: $user->admin,
+            root_admin: $user->root_admin,
+            two_factor_enabled: $user->two_factor_enabled,
+            created_at: $user->created_at,
+            updated_at: $user->updated_at,
+            permissions: $model->permissions,
+        );
+    }
+}

--- a/app/Data/Api/Client/SubuserData.php
+++ b/app/Data/Api/Client/SubuserData.php
@@ -35,7 +35,7 @@ final class SubuserData extends ApiResource
     {
         $user = UserData::fromModel($model->user);
 
-        return new static(
+        return new self(
             uuid: $user->uuid,
             username: $user->username,
             email: $user->email,

--- a/app/Data/Api/Client/SubuserData.php
+++ b/app/Data/Api/Client/SubuserData.php
@@ -6,7 +6,7 @@ use App\Data\Api\ApiResource;
 use App\Models\Subuser;
 use Spatie\LaravelData\Attributes\MapOutputName;
 
-class SubuserData extends ApiResource
+final class SubuserData extends ApiResource
 {
     /**
      * @param  string[]  $permissions

--- a/app/Data/Api/Client/TaskData.php
+++ b/app/Data/Api/Client/TaskData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\Task;
 
-class TaskData extends ApiResource
+final class TaskData extends ApiResource
 {
     public function __construct(
         public int $id,

--- a/app/Data/Api/Client/TaskData.php
+++ b/app/Data/Api/Client/TaskData.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\Task;
+
+class TaskData extends ApiResource
+{
+    public function __construct(
+        public int $id,
+        public int $sequence_id,
+        public string $action,
+        public ?string $payload,
+        public int $time_offset,
+        public bool $is_queued,
+        public bool $continue_on_failure,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return Task::RESOURCE_NAME;
+    }
+
+    public static function fromModel(Task $model): static
+    {
+        return new static(
+            id: $model->id,
+            sequence_id: $model->sequence_id,
+            action: $model->action,
+            payload: $model->payload,
+            time_offset: $model->time_offset,
+            is_queued: $model->is_queued,
+            continue_on_failure: $model->continue_on_failure,
+            created_at: $model->created_at->toAtomString(),
+            updated_at: $model->updated_at->toAtomString(),
+        );
+    }
+}

--- a/app/Data/Api/Client/TaskData.php
+++ b/app/Data/Api/Client/TaskData.php
@@ -26,7 +26,7 @@ final class TaskData extends ApiResource
 
     public static function fromModel(Task $model): static
     {
-        return new static(
+        return new self(
             id: $model->id,
             sequence_id: $model->sequence_id,
             action: $model->action,

--- a/app/Data/Api/Client/UserData.php
+++ b/app/Data/Api/Client/UserData.php
@@ -30,7 +30,7 @@ final class UserData extends ApiResource
 
     public static function fromModel(User $model): static
     {
-        return new static(
+        return new self(
             uuid: $model->uuid,
             username: $model->username,
             email: $model->email,
@@ -39,8 +39,8 @@ final class UserData extends ApiResource
             admin: $model->isRootAdmin(), // deprecated, use "root_admin"
             root_admin: $model->isRootAdmin(),
             two_factor_enabled: filled($model->mfa_app_secret),
-            created_at: static::formatTimestamp($model->created_at),
-            updated_at: static::formatTimestamp($model->updated_at),
+            created_at: self::formatTimestamp($model->created_at),
+            updated_at: self::formatTimestamp($model->updated_at),
         );
     }
 }

--- a/app/Data/Api/Client/UserData.php
+++ b/app/Data/Api/Client/UserData.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\User;
+use Illuminate\Support\Str;
+use Spatie\LaravelData\Attributes\MapOutputName;
+
+class UserData extends ApiResource
+{
+    public function __construct(
+        public string $uuid,
+        public string $username,
+        public string $email,
+        public ?string $language,
+        public string $image,
+        public bool $admin,
+        public bool $root_admin,
+        #[MapOutputName('2fa_enabled')]
+        public bool $two_factor_enabled,
+        public string $created_at,
+        public string $updated_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return User::RESOURCE_NAME;
+    }
+
+    public static function fromModel(User $model): static
+    {
+        return new static(
+            uuid: $model->uuid,
+            username: $model->username,
+            email: $model->email,
+            language: $model->language,
+            image: 'https://gravatar.com/avatar/' . md5(Str::lower($model->email)), // deprecated
+            admin: $model->isRootAdmin(), // deprecated, use "root_admin"
+            root_admin: $model->isRootAdmin(),
+            two_factor_enabled: filled($model->mfa_app_secret),
+            created_at: static::formatTimestamp($model->created_at),
+            updated_at: static::formatTimestamp($model->updated_at),
+        );
+    }
+}

--- a/app/Data/Api/Client/UserData.php
+++ b/app/Data/Api/Client/UserData.php
@@ -7,7 +7,7 @@ use App\Models\User;
 use Illuminate\Support\Str;
 use Spatie\LaravelData\Attributes\MapOutputName;
 
-class UserData extends ApiResource
+final class UserData extends ApiResource
 {
     public function __construct(
         public string $uuid,

--- a/app/Data/Api/Client/UserSSHKeyData.php
+++ b/app/Data/Api/Client/UserSSHKeyData.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace App\Data\Api\Client;
+
+use App\Data\Api\ApiResource;
+use App\Models\UserSSHKey;
+
+class UserSSHKeyData extends ApiResource
+{
+    public function __construct(
+        public string $name,
+        public string $fingerprint,
+        public string $public_key,
+        public string $created_at,
+    ) {}
+
+    public static function getResourceName(): string
+    {
+        return UserSSHKey::RESOURCE_NAME;
+    }
+
+    public static function fromModel(UserSSHKey $model): static
+    {
+        return new static(
+            name: $model->name,
+            fingerprint: $model->fingerprint,
+            public_key: $model->public_key,
+            created_at: $model->created_at->toAtomString(),
+        );
+    }
+}

--- a/app/Data/Api/Client/UserSSHKeyData.php
+++ b/app/Data/Api/Client/UserSSHKeyData.php
@@ -5,7 +5,7 @@ namespace App\Data\Api\Client;
 use App\Data\Api\ApiResource;
 use App\Models\UserSSHKey;
 
-class UserSSHKeyData extends ApiResource
+final class UserSSHKeyData extends ApiResource
 {
     public function __construct(
         public string $name,

--- a/app/Data/Api/Client/UserSSHKeyData.php
+++ b/app/Data/Api/Client/UserSSHKeyData.php
@@ -21,7 +21,7 @@ final class UserSSHKeyData extends ApiResource
 
     public static function fromModel(UserSSHKey $model): static
     {
-        return new static(
+        return new self(
             name: $model->name,
             fingerprint: $model->fingerprint,
             public_key: $model->public_key,

--- a/app/Data/Api/Envelope.php
+++ b/app/Data/Api/Envelope.php
@@ -1,0 +1,89 @@
+<?php
+
+namespace App\Data\Api;
+
+use Illuminate\Container\Container;
+
+/**
+ * Renders ApiResource objects into the panel's wire format: an item is
+ * {object, attributes}, a collection is {object: "list", data: [...]}, and include
+ * fragments nest under attributes.relationships. This is the owned replacement for
+ * the PanelSerializer plus League scope machinery.
+ */
+final class Envelope
+{
+    /**
+     * @param  class-string<ApiResource>  $dataClass
+     * @return array<mixed>
+     */
+    public static function item(mixed $model, string $dataClass, IncludeContext $context, ?string $resourceKey = null): array
+    {
+        if (is_null($model)) {
+            return $context->null();
+        }
+
+        return [
+            'object' => $resourceKey ?? $dataClass::getResourceName(),
+            'attributes' => self::attributes($model, $dataClass, $context),
+        ];
+    }
+
+    /**
+     * @param  iterable<mixed>  $models
+     * @param  class-string<ApiResource>  $dataClass
+     * @return array{object: string, data: array<mixed>}
+     */
+    public static function collection(iterable $models, string $dataClass, IncludeContext $context, ?string $resourceKey = null): array
+    {
+        $key = $resourceKey ?? $dataClass::getResourceName();
+
+        $data = [];
+        foreach ($models as $model) {
+            $data[] = [
+                'object' => $key,
+                'attributes' => self::attributes($model, $dataClass, $context),
+            ];
+        }
+
+        return [
+            'object' => 'list',
+            'data' => $data,
+        ];
+    }
+
+    /**
+     * Hydrate the resource through the container so fromModel can take extra typed
+     * dependencies, then attach default includes and any requested includes that the
+     * resource declares available.
+     *
+     * @param  class-string<ApiResource>  $dataClass
+     * @return array<mixed>
+     */
+    private static function attributes(mixed $model, string $dataClass, IncludeContext $context): array
+    {
+        $resource = Container::getInstance()->call([$dataClass, 'fromModel'], ['model' => $model]);
+
+        $attributes = $resource->toArray();
+
+        $names = $dataClass::$defaultIncludes;
+        foreach ($dataClass::$availableIncludes as $name) {
+            if (!in_array($name, $names, true) && $context->isRequested($name)) {
+                $names[] = $name;
+            }
+        }
+
+        $relationships = [];
+        $resolvers = $names === [] ? [] : $dataClass::includes();
+        foreach ($names as $name) {
+            if (isset($resolvers[$name])) {
+                $relationships[$name] = $resolvers[$name]($model, $context->descend($name));
+            }
+        }
+
+        if ($relationships !== []) {
+            $attributes['relationships'] = $relationships;
+        }
+
+        return $attributes;
+    }
+}

--- a/app/Data/Api/IncludeContext.php
+++ b/app/Data/Api/IncludeContext.php
@@ -1,0 +1,114 @@
+<?php
+
+namespace App\Data\Api;
+
+use App\Models\ApiKey;
+use App\Models\Server;
+use App\Models\User;
+use App\Services\Acl\Api\AdminAcl;
+use Illuminate\Http\Request;
+
+/**
+ * Carries the request, the parsed include paths, and the current position in the
+ * include tree while the envelope renders a resource. Include resolvers use it to
+ * authorize and to build nested envelope fragments.
+ */
+class IncludeContext
+{
+    /**
+     * @param  string[]  $requestedIncludes  dot paths, already trimmed to the recursion limit with parents expanded
+     * @param  string[]  $path  the include names leading to the current scope
+     */
+    public function __construct(
+        public readonly Request $request,
+        public readonly array $requestedIncludes = [],
+        public readonly array $path = [],
+    ) {}
+
+    public function user(): ?User
+    {
+        return $this->request->user();
+    }
+
+    /**
+     * Whether the API key on the request may touch the given resource, mirroring
+     * what BaseTransformer::authorize did for application API includes.
+     */
+    public function allowsAdmin(string $resource): bool
+    {
+        $token = $this->user()?->currentAccessToken();
+        if (!$token instanceof ApiKey || !in_array($token->key_type, [ApiKey::TYPE_ACCOUNT, ApiKey::TYPE_APPLICATION])) {
+            return false;
+        }
+
+        if ($token->key_type === ApiKey::TYPE_ACCOUNT) {
+            return $this->user()->isRootAdmin();
+        }
+
+        return AdminAcl::check($token, $resource);
+    }
+
+    /**
+     * Whether the requesting user holds the given ability on the server, mirroring
+     * BaseClientTransformer::authorize for client API includes.
+     */
+    public function allowsClient(string $ability, ?Server $server = null): bool
+    {
+        return (bool) $this->user()?->can($ability, [$server]);
+    }
+
+    public function isRequested(string $include): bool
+    {
+        return in_array(implode('.', [...$this->path, $include]), $this->requestedIncludes, true);
+    }
+
+    public function descend(string $include): self
+    {
+        return new self($this->request, $this->requestedIncludes, [...$this->path, $include]);
+    }
+
+    /**
+     * @param  class-string<ApiResource>  $dataClass
+     * @return array<mixed>
+     */
+    public function item(mixed $model, string $dataClass, ?string $resourceKey = null): array
+    {
+        return Envelope::item($model, $dataClass, $this, $resourceKey);
+    }
+
+    /**
+     * @param  iterable<mixed>  $models
+     * @param  class-string<ApiResource>  $dataClass
+     * @return array<mixed>
+     */
+    public function collection(iterable $models, string $dataClass, ?string $resourceKey = null): array
+    {
+        return Envelope::collection($models, $dataClass, $this, $resourceKey);
+    }
+
+    /**
+     * Wrap already transformed attributes, for includes that have no backing model
+     * like the database password.
+     *
+     * @param  array<mixed>  $attributes
+     * @return array<mixed>
+     */
+    public function rawItem(array $attributes, string $resourceKey): array
+    {
+        return [
+            'object' => $resourceKey,
+            'attributes' => $attributes,
+        ];
+    }
+
+    /**
+     * @return array{object: string, attributes: null}
+     */
+    public function null(): array
+    {
+        return [
+            'object' => 'null_resource',
+            'attributes' => null,
+        ];
+    }
+}

--- a/app/Data/Api/PanelResponse.php
+++ b/app/Data/Api/PanelResponse.php
@@ -104,7 +104,7 @@ class PanelResponse
         $meta = $this->meta;
 
         if ($this->data instanceof LengthAwarePaginator) {
-            $envelope = Envelope::collection($this->data, $this->dataClass, $context);
+            $envelope = Envelope::collection($this->data->items(), $this->dataClass, $context);
             $meta['pagination'] = $this->pagination($this->data);
         } elseif (is_null($this->data)) {
             $envelope = $context->null();

--- a/app/Data/Api/PanelResponse.php
+++ b/app/Data/Api/PanelResponse.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace App\Data\Api;
+
+use Illuminate\Contracts\Pagination\LengthAwarePaginator;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+/**
+ * Drop-in replacement for the injected Fractal wrapper. Call sites keep the same
+ * fluent chain, item or collection then transformWith then toArray or respond, but
+ * transformWith now takes an ApiResource class string instead of a transformer.
+ *
+ * Include parsing mirrors League Fractal: dot paths are trimmed to the recursion
+ * limit, parents of nested paths are implied, endpoint parseIncludes calls merge
+ * with what the request asked for, and addMeta blocks union with first key winning.
+ */
+class PanelResponse
+{
+    protected mixed $data = null;
+
+    protected bool $isCollection = false;
+
+    /** @var class-string<ApiResource>|null */
+    protected ?string $dataClass = null;
+
+    /** @var string[] */
+    protected array $rawIncludes = [];
+
+    protected int $recursionLimit = 10;
+
+    /** @var array<string, mixed> */
+    protected array $meta = [];
+
+    public function __construct(protected Request $request) {}
+
+    public function item(mixed $data): static
+    {
+        $this->data = $data;
+        $this->isCollection = false;
+
+        return $this;
+    }
+
+    public function collection(mixed $data): static
+    {
+        $this->data = $data;
+        $this->isCollection = true;
+
+        return $this;
+    }
+
+    /**
+     * @param  class-string<ApiResource>  $dataClass
+     */
+    public function transformWith(string $dataClass): static
+    {
+        $this->dataClass = $dataClass;
+
+        return $this;
+    }
+
+    /**
+     * @param  string[]|string  $includes
+     */
+    public function parseIncludes(array|string $includes): static
+    {
+        $includes = is_string($includes) ? explode(',', $includes) : $includes;
+
+        $this->rawIncludes = array_merge($this->rawIncludes, $includes);
+
+        return $this;
+    }
+
+    public function limitRecursion(int $limit): static
+    {
+        $this->recursionLimit = $limit;
+
+        return $this;
+    }
+
+    /**
+     * Union semantics matching Fractalistic: a key set by an earlier call is not
+     * overwritten by a later one.
+     *
+     * @param  array<string, mixed>  ...$blocks
+     */
+    public function addMeta(array ...$blocks): static
+    {
+        foreach ($blocks as $block) {
+            $this->meta += $block;
+        }
+
+        return $this;
+    }
+
+    /**
+     * @return array<mixed>
+     */
+    public function toArray(): array
+    {
+        $context = new IncludeContext($this->request, $this->requestedIncludes());
+
+        $meta = $this->meta;
+
+        if ($this->data instanceof LengthAwarePaginator) {
+            $envelope = Envelope::collection($this->data, $this->dataClass, $context);
+            $meta['pagination'] = $this->pagination($this->data);
+        } elseif (is_null($this->data)) {
+            $envelope = $context->null();
+        } elseif ($this->isCollection) {
+            $envelope = Envelope::collection($this->data, $this->dataClass, $context);
+        } else {
+            $envelope = Envelope::item($this->data, $this->dataClass, $context);
+        }
+
+        if ($meta !== []) {
+            $envelope['meta'] = $meta;
+        }
+
+        return $envelope;
+    }
+
+    public function respond(int $status = 200): JsonResponse
+    {
+        return new JsonResponse($this->toArray(), $status);
+    }
+
+    /**
+     * Normalize the raw include names the way League parsed them: strip parameter
+     * suffixes, trim each dot path to the recursion limit, and imply every parent
+     * of a nested path.
+     *
+     * @return string[]
+     */
+    protected function requestedIncludes(): array
+    {
+        $paths = [];
+
+        foreach ($this->rawIncludes as $include) {
+            $name = trim(explode(':', $include, 2)[0]);
+            if ($name === '') {
+                continue;
+            }
+
+            $segments = array_slice(explode('.', $name), 0, $this->recursionLimit);
+            for ($depth = 1; $depth <= count($segments); $depth++) {
+                $paths[] = implode('.', array_slice($segments, 0, $depth));
+            }
+        }
+
+        return array_values(array_unique($paths));
+    }
+
+    /**
+     * The exact meta.pagination block League's ArraySerializer produced, including
+     * the empty object when there are no previous or next links.
+     *
+     * @return array<string, mixed>
+     */
+    protected function pagination(LengthAwarePaginator $paginator): array
+    {
+        $pagination = [
+            'total' => $paginator->total(),
+            'count' => count($paginator->items()),
+            'per_page' => $paginator->perPage(),
+            'current_page' => $paginator->currentPage(),
+            'total_pages' => $paginator->lastPage(),
+        ];
+
+        $links = [];
+        if ($paginator->currentPage() > 1) {
+            $links['previous'] = $paginator->url($paginator->currentPage() - 1);
+        }
+        if ($paginator->currentPage() < $paginator->lastPage()) {
+            $links['next'] = $paginator->url($paginator->currentPage() + 1);
+        }
+
+        $pagination['links'] = $links === [] ? (object) [] : $links;
+
+        return $pagination;
+    }
+}

--- a/app/Http/Controllers/Api/Application/ApplicationApiController.php
+++ b/app/Http/Controllers/Api/Application/ApplicationApiController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application;
 
+use App\Data\Api\PanelResponse;
 use App\Extensions\Spatie\Fractalistic\Fractal;
 use App\Http\Controllers\Controller;
 use App\Transformers\Api\Application\BaseTransformer;
@@ -16,6 +17,8 @@ abstract class ApplicationApiController extends Controller
     protected Request $request;
 
     protected Fractal $fractal;
+
+    protected PanelResponse $response;
 
     /**
      * ApplicationApiController constructor.
@@ -34,15 +37,19 @@ abstract class ApplicationApiController extends Controller
 
         $this->fractal->parseIncludes($includes);
         $this->fractal->limitRecursion(2);
+
+        $this->response->parseIncludes($includes);
+        $this->response->limitRecursion(2);
     }
 
     /**
      * Perform dependency injection of certain classes needed for core functionality
      * without littering the constructors of classes that extend this abstract.
      */
-    public function loadDependencies(Fractal $fractal, Request $request): void
+    public function loadDependencies(Fractal $fractal, PanelResponse $response, Request $request): void
     {
         $this->fractal = $fractal;
+        $this->response = $response;
         $this->request = $request;
     }
 

--- a/app/Http/Controllers/Api/Application/DatabaseHosts/DatabaseHostController.php
+++ b/app/Http/Controllers/Api/Application/DatabaseHosts/DatabaseHostController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\DatabaseHosts;
 
+use App\Data\Api\Application\DatabaseHostData;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\DatabaseHosts\DeleteDatabaseHostRequest;
 use App\Http\Requests\Api\Application\DatabaseHosts\GetDatabaseHostRequest;
@@ -10,7 +11,6 @@ use App\Http\Requests\Api\Application\DatabaseHosts\UpdateDatabaseHostRequest;
 use App\Models\DatabaseHost;
 use App\Services\Databases\Hosts\HostCreationService;
 use App\Services\Databases\Hosts\HostUpdateService;
-use App\Transformers\Api\Application\DatabaseHostTransformer;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -43,8 +43,8 @@ class DatabaseHostController extends ApplicationApiController
             ->allowedSorts(['id', 'name', 'host'])
             ->paginate($request->query('per_page') ?? 10);
 
-        return $this->fractal->collection($databases)
-            ->transformWith($this->getTransformer(DatabaseHostTransformer::class))
+        return $this->response->collection($databases)
+            ->transformWith(DatabaseHostData::class)
             ->toArray();
     }
 
@@ -57,8 +57,8 @@ class DatabaseHostController extends ApplicationApiController
      */
     public function view(GetDatabaseHostRequest $request, DatabaseHost $databaseHost): array
     {
-        return $this->fractal->item($databaseHost)
-            ->transformWith($this->getTransformer(DatabaseHostTransformer::class))
+        return $this->response->item($databaseHost)
+            ->transformWith(DatabaseHostData::class)
             ->toArray();
     }
 
@@ -74,8 +74,8 @@ class DatabaseHostController extends ApplicationApiController
     {
         $databaseHost = $this->creationService->handle($request->validated());
 
-        return $this->fractal->item($databaseHost)
-            ->transformWith($this->getTransformer(DatabaseHostTransformer::class))
+        return $this->response->item($databaseHost)
+            ->transformWith(DatabaseHostData::class)
             ->addMeta([
                 'resource' => route('api.application.databasehosts.view', [
                     'database_host' => $databaseHost->id,
@@ -97,8 +97,8 @@ class DatabaseHostController extends ApplicationApiController
     {
         $databaseHost = $this->updateService->handle($databaseHost->id, $request->validated());
 
-        return $this->fractal->item($databaseHost)
-            ->transformWith($this->getTransformer(DatabaseHostTransformer::class))
+        return $this->response->item($databaseHost)
+            ->transformWith(DatabaseHostData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Eggs/EggController.php
+++ b/app/Http/Controllers/Api/Application/Eggs/EggController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Eggs;
 
+use App\Data\Api\Application\EggData;
 use App\Enums\EggFormat;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Eggs\ExportEggRequest;
@@ -11,7 +12,6 @@ use App\Http\Requests\Api\Application\Eggs\ImportEggRequest;
 use App\Models\Egg;
 use App\Services\Eggs\Sharing\EggExporterService;
 use App\Services\Eggs\Sharing\EggImporterService;
-use App\Transformers\Api\Application\EggTransformer;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -36,8 +36,8 @@ class EggController extends ApplicationApiController
      */
     public function index(GetEggsRequest $request): array
     {
-        return $this->fractal->collection(Egg::all())
-            ->transformWith($this->getTransformer(EggTransformer::class))
+        return $this->response->collection(Egg::all())
+            ->transformWith(EggData::class)
             ->toArray();
     }
 
@@ -50,8 +50,8 @@ class EggController extends ApplicationApiController
      */
     public function view(GetEggRequest $request, Egg $egg): array
     {
-        return $this->fractal->item($egg)
-            ->transformWith($this->getTransformer(EggTransformer::class))
+        return $this->response->item($egg)
+            ->transformWith(EggData::class)
             ->toArray();
     }
 
@@ -98,8 +98,8 @@ class EggController extends ApplicationApiController
     {
         $egg = $this->importService->fromContent($request->getContent());
 
-        return $this->fractal->item($egg)
-            ->transformWith($this->getTransformer(EggTransformer::class))
+        return $this->response->item($egg)
+            ->transformWith(EggData::class)
             ->respond(201);
     }
 }

--- a/app/Http/Controllers/Api/Application/Mounts/MountController.php
+++ b/app/Http/Controllers/Api/Application/Mounts/MountController.php
@@ -2,6 +2,10 @@
 
 namespace App\Http\Controllers\Api\Application\Mounts;
 
+use App\Data\Api\Application\EggData;
+use App\Data\Api\Application\MountData;
+use App\Data\Api\Application\NodeData;
+use App\Data\Api\Application\ServerData;
 use App\Exceptions\Model\DataValidationException;
 use App\Exceptions\Service\HasActiveServersException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
@@ -17,10 +21,6 @@ use App\Http\Requests\Api\Application\Mounts\UpdateMountServersRequest;
 use App\Http\Requests\Api\Application\Nodes\GetNodesRequest;
 use App\Http\Requests\Api\Application\Servers\GetServerRequest;
 use App\Models\Mount;
-use App\Transformers\Api\Application\EggTransformer;
-use App\Transformers\Api\Application\MountTransformer;
-use App\Transformers\Api\Application\NodeTransformer;
-use App\Transformers\Api\Application\ServerTransformer;
 use Illuminate\Http\JsonResponse;
 use Ramsey\Uuid\Uuid;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -42,8 +42,8 @@ class MountController extends ApplicationApiController
             ->allowedSorts(['id', 'uuid'])
             ->paginate($request->query('per_page') ?? 50);
 
-        return $this->fractal->collection($mounts)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->collection($mounts)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 
@@ -56,8 +56,8 @@ class MountController extends ApplicationApiController
      */
     public function view(GetMountRequest $request, Mount $mount): array
     {
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 
@@ -77,8 +77,8 @@ class MountController extends ApplicationApiController
         $model->saveOrFail();
         $mount = $model->fresh();
 
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->addMeta([
                 'resource' => route('api.application.mounts.view', [
                     'mount' => $mount->id,
@@ -100,8 +100,8 @@ class MountController extends ApplicationApiController
     {
         $mount->forceFill($request->validated())->save();
 
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 
@@ -132,8 +132,8 @@ class MountController extends ApplicationApiController
      */
     public function getEggs(GetEggsRequest $request, Mount $mount): array
     {
-        return $this->fractal->collection($mount->eggs)
-            ->transformWith($this->getTransformer(EggTransformer::class))
+        return $this->response->collection($mount->eggs)
+            ->transformWith(EggData::class)
             ->toArray();
     }
 
@@ -147,8 +147,8 @@ class MountController extends ApplicationApiController
      */
     public function getNodes(GetNodesRequest $request, Mount $mount): array
     {
-        return $this->fractal->collection($mount->nodes)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->collection($mount->nodes)
+            ->transformWith(NodeData::class)
             ->toArray();
     }
 
@@ -161,8 +161,8 @@ class MountController extends ApplicationApiController
      */
     public function getServers(GetServerRequest $request, Mount $mount): array
     {
-        return $this->fractal->collection($mount->servers)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->collection($mount->servers)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 
@@ -177,8 +177,8 @@ class MountController extends ApplicationApiController
     {
         $mount->eggs()->attach($request->validated('eggs'));
 
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 
@@ -193,8 +193,8 @@ class MountController extends ApplicationApiController
     {
         $mount->nodes()->attach($request->validated('nodes'));
 
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 
@@ -209,8 +209,8 @@ class MountController extends ApplicationApiController
     {
         $mount->servers()->attach($request->validated('servers'));
 
-        return $this->fractal->item($mount)
-            ->transformWith($this->getTransformer(MountTransformer::class))
+        return $this->response->item($mount)
+            ->transformWith(MountData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Nodes/AllocationController.php
+++ b/app/Http/Controllers/Api/Application/Nodes/AllocationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Nodes;
 
+use App\Data\Api\Application\AllocationData;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Service\Allocation\CidrOutOfRangeException;
 use App\Exceptions\Service\Allocation\InvalidPortMappingException;
@@ -14,7 +15,6 @@ use App\Http\Requests\Api\Application\Allocations\StoreAllocationRequest;
 use App\Models\Allocation;
 use App\Models\Node;
 use App\Services\Allocations\AssignmentService;
-use App\Transformers\Api\Application\AllocationTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Http\JsonResponse;
@@ -57,8 +57,8 @@ class AllocationController extends ApplicationApiController
             ])
             ->paginate($request->query('per_page') ?? 50);
 
-        return $this->fractal->collection($allocations)
-            ->transformWith($this->getTransformer(AllocationTransformer::class))
+        return $this->response->collection($allocations)
+            ->transformWith(AllocationData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Nodes/NodeController.php
+++ b/app/Http/Controllers/Api/Application/Nodes/NodeController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Nodes;
 
+use App\Data\Api\Application\NodeData;
 use App\Exceptions\Model\DataValidationException;
 use App\Exceptions\Service\HasActiveServersException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
@@ -13,7 +14,6 @@ use App\Http\Requests\Api\Application\Nodes\UpdateNodeRequest;
 use App\Models\Node;
 use App\Services\Nodes\NodeDeletionService;
 use App\Services\Nodes\NodeUpdateService;
-use App\Transformers\Api\Application\NodeTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -47,8 +47,8 @@ class NodeController extends ApplicationApiController
             ->allowedSorts(['id', 'uuid', 'memory', 'disk', 'cpu'])
             ->paginate($request->query('per_page') ?? 50);
 
-        return $this->fractal->collection($nodes)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->collection($nodes)
+            ->transformWith(NodeData::class)
             ->toArray();
     }
 
@@ -61,8 +61,8 @@ class NodeController extends ApplicationApiController
      */
     public function view(GetNodeRequest $request, Node $node): array
     {
-        return $this->fractal->item($node)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->item($node)
+            ->transformWith(NodeData::class)
             ->toArray();
     }
 
@@ -78,8 +78,8 @@ class NodeController extends ApplicationApiController
     {
         $node = Node::create($request->validated());
 
-        return $this->fractal->item($node)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->item($node)
+            ->transformWith(NodeData::class)
             ->addMeta([
                 'resource' => route('api.application.nodes.view', [
                     'node' => $node->id,
@@ -109,8 +109,8 @@ class NodeController extends ApplicationApiController
             report($exception);
         }
 
-        return $this->fractal->item($node)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->item($node)
+            ->transformWith(NodeData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Nodes/NodeDeploymentController.php
+++ b/app/Http/Controllers/Api/Application/Nodes/NodeDeploymentController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\Application\Nodes;
 
+use App\Data\Api\Application\NodeData;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Nodes\GetDeployableNodesRequest;
 use App\Services\Deployment\FindViableNodesService;
-use App\Transformers\Api\Application\NodeTransformer;
 use Dedoc\Scramble\Attributes\Group;
 
 #[Group('Node', weight: 2)]
@@ -36,8 +36,8 @@ class NodeDeploymentController extends ApplicationApiController
             $data['tags'] ?? [],
         );
 
-        return $this->fractal->collection($nodes)
-            ->transformWith($this->getTransformer(NodeTransformer::class))
+        return $this->response->collection($nodes)
+            ->transformWith(NodeData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Plugins/PluginController.php
+++ b/app/Http/Controllers/Api/Application/Plugins/PluginController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Plugins;
 
+use App\Data\Api\Application\PluginData;
 use App\Enums\PluginStatus;
 use App\Exceptions\PanelException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
@@ -11,7 +12,6 @@ use App\Http\Requests\Api\Application\Plugins\UninstallPluginRequest;
 use App\Http\Requests\Api\Application\Plugins\WritePluginRequest;
 use App\Models\Plugin;
 use App\Services\Helpers\PluginService;
-use App\Transformers\Api\Application\PluginTransformer;
 use Exception;
 use Illuminate\Http\Response;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -40,8 +40,8 @@ class PluginController extends ApplicationApiController
             ->allowedSorts(['id', 'name', 'author', 'category'])
             ->paginate($request->query('per_page') ?? 10);
 
-        return $this->fractal->collection($plugins)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->collection($plugins)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -54,8 +54,8 @@ class PluginController extends ApplicationApiController
      */
     public function view(ReadPluginRequest $request, Plugin $plugin): array
     {
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -104,8 +104,8 @@ class PluginController extends ApplicationApiController
 
         $this->pluginService->installPlugin($plugin);
 
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -124,8 +124,8 @@ class PluginController extends ApplicationApiController
 
         $this->pluginService->updatePlugin($plugin);
 
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -144,8 +144,8 @@ class PluginController extends ApplicationApiController
 
         $this->pluginService->uninstallPlugin($plugin, $request->boolean('delete'));
 
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -164,8 +164,8 @@ class PluginController extends ApplicationApiController
 
         $this->pluginService->enablePlugin($plugin);
 
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 
@@ -184,8 +184,8 @@ class PluginController extends ApplicationApiController
 
         $this->pluginService->disablePlugin($plugin);
 
-        return $this->fractal->item($plugin)
-            ->transformWith($this->getTransformer(PluginTransformer::class))
+        return $this->response->item($plugin)
+            ->transformWith(PluginData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Roles/RoleController.php
+++ b/app/Http/Controllers/Api/Application/Roles/RoleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Roles;
 
+use App\Data\Api\Application\RoleData;
 use App\Exceptions\PanelException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Roles\DeleteRoleRequest;
@@ -9,7 +10,6 @@ use App\Http\Requests\Api\Application\Roles\GetRoleRequest;
 use App\Http\Requests\Api\Application\Roles\StoreRoleRequest;
 use App\Http\Requests\Api\Application\Roles\UpdateRoleRequest;
 use App\Models\Role;
-use App\Transformers\Api\Application\RoleTransformer;
 use Exception;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -32,8 +32,8 @@ class RoleController extends ApplicationApiController
             ->allowedSorts(['id', 'name'])
             ->paginate($request->query('per_page') ?? 10);
 
-        return $this->fractal->collection($roles)
-            ->transformWith($this->getTransformer(RoleTransformer::class))
+        return $this->response->collection($roles)
+            ->transformWith(RoleData::class)
             ->toArray();
     }
 
@@ -46,8 +46,8 @@ class RoleController extends ApplicationApiController
      */
     public function view(GetRoleRequest $request, Role $role): array
     {
-        return $this->fractal->item($role)
-            ->transformWith($this->getTransformer(RoleTransformer::class))
+        return $this->response->item($role)
+            ->transformWith(RoleData::class)
             ->toArray();
     }
 
@@ -63,8 +63,8 @@ class RoleController extends ApplicationApiController
     {
         $role = Role::create($request->validated());
 
-        return $this->fractal->item($role)
-            ->transformWith($this->getTransformer(RoleTransformer::class))
+        return $this->response->item($role)
+            ->transformWith(RoleData::class)
             ->addMeta([
                 'resource' => route('api.application.roles.view', [
                     'role' => $role->id,
@@ -88,8 +88,8 @@ class RoleController extends ApplicationApiController
 
         $role->update($request->validated());
 
-        return $this->fractal->item($role)
-            ->transformWith($this->getTransformer(RoleTransformer::class))
+        return $this->response->item($role)
+            ->transformWith(RoleData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Servers/DatabaseController.php
+++ b/app/Http/Controllers/Api/Application/Servers/DatabaseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Servers;
 
+use App\Data\Api\Application\ServerDatabaseData;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Servers\Databases\GetServerDatabaseRequest;
 use App\Http\Requests\Api\Application\Servers\Databases\GetServerDatabasesRequest;
@@ -10,7 +11,6 @@ use App\Http\Requests\Api\Application\Servers\Databases\StoreServerDatabaseReque
 use App\Models\Database;
 use App\Models\Server;
 use App\Services\Databases\DatabaseManagementService;
-use App\Transformers\Api\Application\ServerDatabaseTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -37,8 +37,8 @@ class DatabaseController extends ApplicationApiController
      */
     public function index(GetServerDatabasesRequest $request, Server $server): array
     {
-        return $this->fractal->collection($server->databases)
-            ->transformWith($this->getTransformer(ServerDatabaseTransformer::class))
+        return $this->response->collection($server->databases)
+            ->transformWith(ServerDatabaseData::class)
             ->toArray();
     }
 
@@ -51,8 +51,8 @@ class DatabaseController extends ApplicationApiController
      */
     public function view(GetServerDatabaseRequest $request, Server $server, Database $database): array
     {
-        return $this->fractal->item($database)
-            ->transformWith($this->getTransformer(ServerDatabaseTransformer::class))
+        return $this->response->item($database)
+            ->transformWith(ServerDatabaseData::class)
             ->toArray();
     }
 
@@ -83,8 +83,8 @@ class DatabaseController extends ApplicationApiController
             'database' => $request->databaseName(),
         ]));
 
-        return $this->fractal->item($database)
-            ->transformWith($this->getTransformer(ServerDatabaseTransformer::class))
+        return $this->response->item($database)
+            ->transformWith(ServerDatabaseData::class)
             ->addMeta([
                 'resource' => route('api.application.servers.databases.view', [
                     'server' => $server->id,

--- a/app/Http/Controllers/Api/Application/Servers/ExternalServerController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ExternalServerController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\Application\Servers;
 
+use App\Data\Api\Application\ServerData;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Servers\GetExternalServerRequest;
 use App\Models\Server;
-use App\Transformers\Api\Application\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 
 #[Group('Server', weight: 1)]
@@ -22,8 +22,8 @@ class ExternalServerController extends ApplicationApiController
     {
         $server = Server::query()->where('external_id', $external_id)->firstOrFail();
 
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Servers/ServerController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ServerController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Servers;
 
+use App\Data\Api\Application\ServerData;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Model\DataValidationException;
 use App\Exceptions\Service\Deployment\NoViableAllocationException;
@@ -13,7 +14,6 @@ use App\Http\Requests\Api\Application\Servers\StoreServerRequest;
 use App\Models\Server;
 use App\Services\Servers\ServerCreationService;
 use App\Services\Servers\ServerDeletionService;
-use App\Transformers\Api\Application\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Response;
@@ -48,8 +48,8 @@ class ServerController extends ApplicationApiController
             ->allowedSorts(['id', 'uuid'])
             ->paginate($request->query('per_page') ?? 50);
 
-        return $this->fractal->collection($servers)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->collection($servers)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 
@@ -68,8 +68,8 @@ class ServerController extends ApplicationApiController
     {
         $server = $this->creationService->handle($request->validated(), $request->getDeploymentObject());
 
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->respond(201);
     }
 
@@ -82,8 +82,8 @@ class ServerController extends ApplicationApiController
      */
     public function view(GetServerRequest $request, Server $server): array
     {
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Application/Servers/ServerDetailsController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ServerDetailsController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Servers;
 
+use App\Data\Api\Application\ServerData;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Model\DataValidationException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
@@ -10,7 +11,6 @@ use App\Http\Requests\Api\Application\Servers\UpdateServerDetailsRequest;
 use App\Models\Server;
 use App\Services\Servers\BuildModificationService;
 use App\Services\Servers\DetailsModificationService;
-use App\Transformers\Api\Application\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 
 #[Group('Server', weight: 2)]
@@ -46,8 +46,8 @@ class ServerDetailsController extends ApplicationApiController
             $validated,
         );
 
-        return $this->fractal->item($updated)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($updated)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 
@@ -65,8 +65,8 @@ class ServerDetailsController extends ApplicationApiController
     {
         $server = $this->buildModificationService->handle($server, $request->validated());
 
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Servers/StartupController.php
+++ b/app/Http/Controllers/Api/Application/Servers/StartupController.php
@@ -2,13 +2,13 @@
 
 namespace App\Http\Controllers\Api\Application\Servers;
 
+use App\Data\Api\Application\ServerData;
 use App\Exceptions\Model\DataValidationException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Servers\UpdateServerStartupRequest;
 use App\Models\Server;
 use App\Models\User;
 use App\Services\Servers\StartupModificationService;
-use App\Transformers\Api\Application\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Validation\ValidationException;
@@ -41,8 +41,8 @@ class StartupController extends ApplicationApiController
             ->setUserLevel(User::USER_LEVEL_ADMIN)
             ->handle($server, $request->validated());
 
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Users/ExternalUserController.php
+++ b/app/Http/Controllers/Api/Application/Users/ExternalUserController.php
@@ -2,10 +2,10 @@
 
 namespace App\Http\Controllers\Api\Application\Users;
 
+use App\Data\Api\Application\UserData;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Users\GetExternalUserRequest;
 use App\Models\User;
-use App\Transformers\Api\Application\UserTransformer;
 use Dedoc\Scramble\Attributes\Group;
 
 #[Group('User', weight: 1)]
@@ -22,8 +22,8 @@ class ExternalUserController extends ApplicationApiController
     {
         $user = User::query()->where('external_id', $externalId)->firstOrFail();
 
-        return $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class))
+        return $this->response->item($user)
+            ->transformWith(UserData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Application/Users/UserController.php
+++ b/app/Http/Controllers/Api/Application/Users/UserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Application\Users;
 
+use App\Data\Api\Application\UserData;
 use App\Exceptions\Model\DataValidationException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Users\AssignUserRolesRequest;
@@ -13,7 +14,6 @@ use App\Models\Role;
 use App\Models\User;
 use App\Services\Users\UserCreationService;
 use App\Services\Users\UserUpdateService;
-use App\Transformers\Api\Application\UserTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -48,8 +48,8 @@ class UserController extends ApplicationApiController
             ->allowedSorts(['id', 'uuid'])
             ->paginate($request->query('per_page') ?? 50);
 
-        return $this->fractal->collection($users)
-            ->transformWith($this->getTransformer(UserTransformer::class))
+        return $this->response->collection($users)
+            ->transformWith(UserData::class)
             ->toArray();
     }
 
@@ -63,8 +63,8 @@ class UserController extends ApplicationApiController
      */
     public function view(GetUsersRequest $request, User $user): array
     {
-        return $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class))
+        return $this->response->item($user)
+            ->transformWith(UserData::class)
             ->toArray();
     }
 
@@ -87,8 +87,8 @@ class UserController extends ApplicationApiController
         $this->updateService->setUserLevel(User::USER_LEVEL_ADMIN);
         $user = $this->updateService->handle($user, $request->validated());
 
-        $response = $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class));
+        $response = $this->response->item($user)
+            ->transformWith(UserData::class);
 
         return $response->toArray();
     }
@@ -113,8 +113,8 @@ class UserController extends ApplicationApiController
             }
         }
 
-        $response = $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class));
+        $response = $this->response->item($user)
+            ->transformWith(UserData::class);
 
         return $response->toArray();
     }
@@ -139,8 +139,8 @@ class UserController extends ApplicationApiController
             }
         }
 
-        $response = $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class));
+        $response = $this->response->item($user)
+            ->transformWith(UserData::class);
 
         return $response->toArray();
     }
@@ -158,8 +158,8 @@ class UserController extends ApplicationApiController
     {
         $user = $this->creationService->handle($request->validated());
 
-        return $this->fractal->item($user)
-            ->transformWith($this->getTransformer(UserTransformer::class))
+        return $this->response->item($user)
+            ->transformWith(UserData::class)
             ->addMeta([
                 'resource' => route('api.application.users.view', [
                     'user' => $user->id,

--- a/app/Http/Controllers/Api/Client/AccountController.php
+++ b/app/Http/Controllers/Api/Client/AccountController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Api\Client;
 
+use App\Data\Api\Client\UserData;
 use App\Facades\Activity;
 use App\Http\Requests\Api\Client\Account\UpdateEmailRequest;
 use App\Http\Requests\Api\Client\Account\UpdatePasswordRequest;
 use App\Http\Requests\Api\Client\Account\UpdateUsernameRequest;
 use App\Services\Users\UserUpdateService;
-use App\Transformers\Api\Client\UserTransformer;
 use Illuminate\Auth\AuthManager;
 use Illuminate\Auth\SessionGuard;
 use Illuminate\Http\JsonResponse;
@@ -41,8 +41,8 @@ class AccountController extends ClientApiController
      */
     public function index(Request $request): array
     {
-        return $this->fractal->item($request->user())
-            ->transformWith($this->getTransformer(UserTransformer::class))
+        return $this->response->item($request->user())
+            ->transformWith(UserData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/ActivityLogController.php
+++ b/app/Http/Controllers/Api/Client/ActivityLogController.php
@@ -2,9 +2,9 @@
 
 namespace App\Http\Controllers\Api\Client;
 
+use App\Data\Api\Client\ActivityLogData;
 use App\Http\Requests\Api\Client\ClientApiRequest;
 use App\Models\ActivityLog;
-use App\Transformers\Api\Client\ActivityLogTransformer;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
 
@@ -27,8 +27,8 @@ class ActivityLogController extends ClientApiController
             ->paginate(min($request->query('per_page', '25'), 100))
             ->appends($request->query());
 
-        return $this->fractal->collection($activity)
-            ->transformWith($this->getTransformer(ActivityLogTransformer::class))
+        return $this->response->collection($activity)
+            ->transformWith(ActivityLogData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Client/ApiKeyController.php
+++ b/app/Http/Controllers/Api/Client/ApiKeyController.php
@@ -2,12 +2,12 @@
 
 namespace App\Http\Controllers\Api\Client;
 
+use App\Data\Api\Client\ApiKeyData;
 use App\Exceptions\DisplayException;
 use App\Facades\Activity;
 use App\Http\Requests\Api\Client\Account\StoreApiKeyRequest;
 use App\Http\Requests\Api\Client\ClientApiRequest;
 use App\Models\ApiKey;
-use App\Transformers\Api\Client\ApiKeyTransformer;
 use Illuminate\Http\JsonResponse;
 
 class ApiKeyController extends ClientApiController
@@ -21,8 +21,8 @@ class ApiKeyController extends ClientApiController
      */
     public function index(ClientApiRequest $request): array
     {
-        return $this->fractal->collection($request->user()->apiKeys)
-            ->transformWith($this->getTransformer(ApiKeyTransformer::class))
+        return $this->response->collection($request->user()->apiKeys)
+            ->transformWith(ApiKeyData::class)
             ->toArray();
     }
 
@@ -49,8 +49,8 @@ class ApiKeyController extends ClientApiController
             ->property('identifier', $token->accessToken->identifier)
             ->log();
 
-        return $this->fractal->item($token->accessToken)
-            ->transformWith($this->getTransformer(ApiKeyTransformer::class))
+        return $this->response->item($token->accessToken)
+            ->transformWith(ApiKeyData::class)
             ->addMeta(['secret_token' => $token->plainTextToken])
             ->toArray();
     }

--- a/app/Http/Controllers/Api/Client/ClientController.php
+++ b/app/Http/Controllers/Api/Client/ClientController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\Client;
 
+use App\Data\Api\Client\ServerData;
 use App\Http\Requests\Api\Client\GetServersRequest;
 use App\Models\Filters\MultiFieldServerFilter;
 use App\Models\Server;
 use App\Models\Subuser;
-use App\Transformers\Api\Client\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Model;
@@ -35,10 +35,12 @@ class ClientController extends ClientApiController
     public function index(GetServersRequest $request): array
     {
         $user = $request->user();
-        $transformer = $this->getTransformer(ServerTransformer::class);
+
+        // Only eager load the relationships that map to includes the resource honors.
+        $includes = array_values(array_intersect($this->parseIncludes(), ServerData::$availableIncludes));
 
         /** @var Builder<Model> $query */
-        $query = Server::query()->with($this->getIncludesForTransformer($transformer, ['node']));
+        $query = Server::query()->with(array_merge($includes, ['node']));
 
         // Start the query builder and ensure we eager load any requested relationships from the request.
         $builder = QueryBuilder::for($query)->allowedFilters([
@@ -72,7 +74,7 @@ class ClientController extends ClientApiController
 
         $servers = $builder->paginate(min($request->query('per_page', '50'), 100))->appends($request->query());
 
-        return $this->fractal->transformWith($transformer)->collection($servers)->toArray();
+        return $this->response->transformWith(ServerData::class)->collection($servers)->toArray();
     }
 
     /**

--- a/app/Http/Controllers/Api/Client/SSHKeyController.php
+++ b/app/Http/Controllers/Api/Client/SSHKeyController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\Client;
 
+use App\Data\Api\Client\UserSSHKeyData;
 use App\Facades\Activity;
 use App\Http\Requests\Api\Client\Account\StoreSSHKeyRequest;
 use App\Http\Requests\Api\Client\ClientApiRequest;
 use App\Models\UserSSHKey;
-use App\Transformers\Api\Client\UserSSHKeyTransformer;
 use Illuminate\Http\JsonResponse;
 
 class SSHKeyController extends ClientApiController
@@ -20,8 +20,8 @@ class SSHKeyController extends ClientApiController
      */
     public function index(ClientApiRequest $request): array
     {
-        return $this->fractal->collection($request->user()->sshKeys)
-            ->transformWith($this->getTransformer(UserSSHKeyTransformer::class))
+        return $this->response->collection($request->user()->sshKeys)
+            ->transformWith(UserSSHKeyData::class)
             ->toArray();
     }
 
@@ -45,8 +45,8 @@ class SSHKeyController extends ClientApiController
             ->property('fingerprint', $request->getKeyFingerprint())
             ->log();
 
-        return $this->fractal->item($model)
-            ->transformWith($this->getTransformer(UserSSHKeyTransformer::class))
+        return $this->response->item($model)
+            ->transformWith(UserSSHKeyData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/ActivityLogController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ActivityLogController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\ActivityLogData;
 use App\Enums\SubuserPermission;
 use App\Http\Controllers\Api\Client\ClientApiController;
 use App\Http\Requests\Api\Client\ClientApiRequest;
@@ -9,7 +10,6 @@ use App\Models\ActivityLog;
 use App\Models\Role;
 use App\Models\Server;
 use App\Models\User;
-use App\Transformers\Api\Client\ActivityLogTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Query\JoinClause;
@@ -56,8 +56,8 @@ class ActivityLogController extends ClientApiController
             ->paginate(min($request->query('per_page', '25'), 100))
             ->appends($request->query());
 
-        return $this->fractal->collection($activity)
-            ->transformWith($this->getTransformer(ActivityLogTransformer::class))
+        return $this->response->collection($activity)
+            ->transformWith(ActivityLogData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Client/Servers/BackupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/BackupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\BackupData;
 use App\Enums\ServerState;
 use App\Enums\SubuserPermission;
 use App\Extensions\BackupAdapter\BackupAdapterService;
@@ -16,7 +17,6 @@ use App\Repositories\Daemon\DaemonBackupRepository;
 use App\Services\Backups\DeleteBackupService;
 use App\Services\Backups\DownloadLinkService;
 use App\Services\Backups\InitiateBackupService;
-use App\Transformers\Api\Client\BackupTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Auth\Access\AuthorizationException;
 use Illuminate\Http\JsonResponse;
@@ -54,8 +54,8 @@ class BackupController extends ClientApiController
 
         $limit = min($request->query('per_page') ?? 20, 50);
 
-        return $this->fractal->collection($server->backups()->paginate($limit))
-            ->transformWith($this->getTransformer(BackupTransformer::class))
+        return $this->response->collection($server->backups()->paginate($limit))
+            ->transformWith(BackupData::class)
             ->addMeta([
                 'backup_count' => $server->backups()->nonFailed()->count(),
             ])
@@ -99,8 +99,8 @@ class BackupController extends ClientApiController
             return $backup;
         });
 
-        return $this->fractal->item($backup)
-            ->transformWith($this->getTransformer(BackupTransformer::class))
+        return $this->response->item($backup)
+            ->transformWith(BackupData::class)
             ->toArray();
     }
 
@@ -124,8 +124,8 @@ class BackupController extends ClientApiController
 
         Activity::event($action)->subject($backup)->property('name', $backup->name)->log();
 
-        return $this->fractal->item($backup)
-            ->transformWith($this->getTransformer(BackupTransformer::class))
+        return $this->response->item($backup)
+            ->transformWith(BackupData::class)
             ->toArray();
     }
 
@@ -142,8 +142,8 @@ class BackupController extends ClientApiController
     {
         throw_unless($request->user()->can(SubuserPermission::BackupRead, $server), new AuthorizationException());
 
-        return $this->fractal->item($backup)
-            ->transformWith($this->getTransformer(BackupTransformer::class))
+        return $this->response->item($backup)
+            ->transformWith(BackupData::class)
             ->toArray();
     }
 
@@ -222,8 +222,8 @@ class BackupController extends ClientApiController
                 ->log();
         }
 
-        return $this->fractal->item($backup)
-            ->transformWith($this->getTransformer(BackupTransformer::class))
+        return $this->response->item($backup)
+            ->transformWith(BackupData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/DatabaseController.php
+++ b/app/Http/Controllers/Api/Client/Servers/DatabaseController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\DatabaseData;
 use App\Exceptions\Service\Database\DatabaseClientFeatureNotEnabledException;
 use App\Exceptions\Service\Database\TooManyDatabasesException;
 use App\Facades\Activity;
@@ -14,7 +15,6 @@ use App\Models\Database;
 use App\Models\Server;
 use App\Services\Databases\DatabaseManagementService;
 use App\Services\Databases\DeployServerDatabaseService;
-use App\Transformers\Api\Client\DatabaseTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\Response;
 use Throwable;
@@ -41,8 +41,8 @@ class DatabaseController extends ClientApiController
      */
     public function index(GetDatabasesRequest $request, Server $server): array
     {
-        return $this->fractal->collection($server->databases)
-            ->transformWith($this->getTransformer(DatabaseTransformer::class))
+        return $this->response->collection($server->databases)
+            ->transformWith(DatabaseData::class)
             ->toArray();
     }
 
@@ -69,9 +69,9 @@ class DatabaseController extends ClientApiController
             return $database;
         });
 
-        return $this->fractal->item($database)
+        return $this->response->item($database)
             ->parseIncludes(['password'])
-            ->transformWith($this->getTransformer(DatabaseTransformer::class))
+            ->transformWith(DatabaseData::class)
             ->toArray();
     }
 
@@ -92,9 +92,9 @@ class DatabaseController extends ClientApiController
             ->property('name', $database->database)
             ->transaction(fn () => $this->managementService->rotatePassword($database));
 
-        return $this->fractal->item($database->refresh())
+        return $this->response->item($database->refresh())
             ->parseIncludes(['password'])
-            ->transformWith($this->getTransformer(DatabaseTransformer::class))
+            ->transformWith(DatabaseData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\FileObjectData;
 use App\Enums\NodeJwtScope;
 use App\Facades\Activity;
 use App\Http\Controllers\Api\Client\ClientApiController;
@@ -19,7 +20,6 @@ use App\Http\Requests\Api\Client\Servers\Files\WriteFileContentRequest;
 use App\Models\Server;
 use App\Repositories\Daemon\DaemonFileRepository;
 use App\Services\Nodes\NodeJWTService;
-use App\Transformers\Api\Client\FileObjectTransformer;
 use Carbon\CarbonImmutable;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\Client\ConnectionException;
@@ -55,8 +55,8 @@ class FileController extends ClientApiController
             ->setServer($server)
             ->getDirectory($request->get('directory') ?? '/');
 
-        return $this->fractal->collection($contents)
-            ->transformWith($this->getTransformer(FileObjectTransformer::class))
+        return $this->response->collection($contents)
+            ->transformWith(FileObjectData::class)
             ->toArray();
     }
 
@@ -227,8 +227,8 @@ class FileController extends ClientApiController
             ->property('files', $request->input('files'))
             ->log();
 
-        return $this->fractal->item($file)
-            ->transformWith($this->getTransformer(FileObjectTransformer::class))
+        return $this->response->item($file)
+            ->transformWith(FileObjectData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/NetworkAllocationController.php
+++ b/app/Http/Controllers/Api/Client/Servers/NetworkAllocationController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\AllocationData;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Model\DataValidationException;
 use App\Facades\Activity;
@@ -14,7 +15,6 @@ use App\Http\Requests\Api\Client\Servers\Network\UpdateAllocationRequest;
 use App\Models\Allocation;
 use App\Models\Server;
 use App\Services\Allocations\FindAssignableAllocationService;
-use App\Transformers\Api\Client\AllocationTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 
@@ -40,8 +40,8 @@ class NetworkAllocationController extends ClientApiController
      */
     public function index(GetNetworkRequest $request, Server $server): array
     {
-        return $this->fractal->collection($server->allocations)
-            ->transformWith($this->getTransformer(AllocationTransformer::class))
+        return $this->response->collection($server->allocations)
+            ->transformWith(AllocationData::class)
             ->toArray();
     }
 
@@ -67,8 +67,8 @@ class NetworkAllocationController extends ClientApiController
                 ->log();
         }
 
-        return $this->fractal->item($allocation)
-            ->transformWith($this->getTransformer(AllocationTransformer::class))
+        return $this->response->item($allocation)
+            ->transformWith(AllocationData::class)
             ->toArray();
     }
 
@@ -91,8 +91,8 @@ class NetworkAllocationController extends ClientApiController
             ->property('allocation', $allocation->address)
             ->log();
 
-        return $this->fractal->item($allocation)
-            ->transformWith($this->getTransformer(AllocationTransformer::class))
+        return $this->response->item($allocation)
+            ->transformWith(AllocationData::class)
             ->toArray();
     }
 
@@ -119,8 +119,8 @@ class NetworkAllocationController extends ClientApiController
             return $allocation;
         });
 
-        return $this->fractal->item($allocation)
-            ->transformWith($this->getTransformer(AllocationTransformer::class))
+        return $this->response->item($allocation)
+            ->transformWith(AllocationData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ResourceUtilizationController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\StatsData;
 use App\Http\Controllers\Api\Client\ClientApiController;
 use App\Http\Requests\Api\Client\Servers\GetServerRequest;
 use App\Models\Server;
 use App\Repositories\Daemon\DaemonServerRepository;
-use App\Transformers\Api\Client\StatsTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Cache\Repository;
 use Illuminate\Http\Client\ConnectionException;
@@ -41,8 +41,8 @@ class ResourceUtilizationController extends ClientApiController
             return $this->repository->setServer($server)->getDetails();
         });
 
-        return $this->fractal->item($stats)
-            ->transformWith($this->getTransformer(StatsTransformer::class))
+        return $this->response->item($stats)
+            ->transformWith(StatsData::class)
             ->toArray();
     }
 }

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\ScheduleData;
 use App\Exceptions\DisplayException;
 use App\Exceptions\Model\DataValidationException;
 use App\Facades\Activity;
@@ -15,7 +16,6 @@ use App\Http\Requests\Api\Client\Servers\Schedules\ViewScheduleRequest;
 use App\Models\Schedule;
 use App\Models\Server;
 use App\Services\Schedules\ProcessScheduleService;
-use App\Transformers\Api\Client\ScheduleTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Http\JsonResponse;
@@ -47,8 +47,8 @@ class ScheduleController extends ClientApiController
     {
         $schedules = $server->schedules->loadMissing('tasks');
 
-        return $this->fractal->collection($schedules)
-            ->transformWith($this->getTransformer(ScheduleTransformer::class))
+        return $this->response->collection($schedules)
+            ->transformWith(ScheduleData::class)
             ->toArray();
     }
 
@@ -83,8 +83,8 @@ class ScheduleController extends ClientApiController
             ->property('name', $model->name)
             ->log();
 
-        return $this->fractal->item($model)
-            ->transformWith($this->getTransformer(ScheduleTransformer::class))
+        return $this->response->item($model)
+            ->transformWith(ScheduleData::class)
             ->toArray();
     }
 
@@ -101,8 +101,8 @@ class ScheduleController extends ClientApiController
 
         $schedule->loadMissing('tasks');
 
-        return $this->fractal->item($schedule)
-            ->transformWith($this->getTransformer(ScheduleTransformer::class))
+        return $this->response->item($schedule)
+            ->transformWith(ScheduleData::class)
             ->toArray();
     }
 
@@ -145,8 +145,8 @@ class ScheduleController extends ClientApiController
             ->property(['name' => $schedule->name, 'active' => $active])
             ->log();
 
-        return $this->fractal->item($schedule->refresh())
-            ->transformWith($this->getTransformer(ScheduleTransformer::class))
+        return $this->response->item($schedule->refresh())
+            ->transformWith(ScheduleData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/ScheduleTaskController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ScheduleTaskController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\TaskData;
 use App\Enums\SubuserPermission;
 use App\Exceptions\Http\HttpForbiddenException;
 use App\Exceptions\Model\DataValidationException;
@@ -13,7 +14,6 @@ use App\Http\Requests\Api\Client\Servers\Schedules\StoreTaskRequest;
 use App\Models\Schedule;
 use App\Models\Server;
 use App\Models\Task;
-use App\Transformers\Api\Client\TaskTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Exception;
 use Illuminate\Database\ConnectionInterface;
@@ -89,8 +89,8 @@ class ScheduleTaskController extends ClientApiController
             ->property(['name' => $schedule->name, 'action' => $task->action, 'payload' => $task->payload])
             ->log();
 
-        return $this->fractal->item($task)
-            ->transformWith($this->getTransformer(TaskTransformer::class))
+        return $this->response->item($task)
+            ->transformWith(TaskData::class)
             ->toArray();
     }
 
@@ -143,8 +143,8 @@ class ScheduleTaskController extends ClientApiController
             ->property(['name' => $schedule->name, 'action' => $task->action, 'payload' => $task->payload])
             ->log();
 
-        return $this->fractal->item($task->refresh())
-            ->transformWith($this->getTransformer(TaskTransformer::class))
+        return $this->response->item($task->refresh())
+            ->transformWith(TaskData::class)
             ->toArray();
     }
 

--- a/app/Http/Controllers/Api/Client/Servers/ServerController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ServerController.php
@@ -2,11 +2,11 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\ServerData;
 use App\Http\Controllers\Api\Client\ClientApiController;
 use App\Http\Requests\Api\Client\Servers\GetServerRequest;
 use App\Models\Server;
 use App\Services\Servers\GetUserPermissionsService;
-use App\Transformers\Api\Client\ServerTransformer;
 use Dedoc\Scramble\Attributes\Group;
 
 #[Group('Server', weight: 0)]
@@ -26,8 +26,8 @@ class ServerController extends ClientApiController
      */
     public function index(GetServerRequest $request, Server $server): array
     {
-        return $this->fractal->item($server)
-            ->transformWith($this->getTransformer(ServerTransformer::class))
+        return $this->response->item($server)
+            ->transformWith(ServerData::class)
             ->addMeta([
                 'is_server_owner' => $request->user()->id === $server->owner_id,
                 'user_permissions' => $this->permissionsService->handle($server, $request->user()),

--- a/app/Http/Controllers/Api/Client/Servers/StartupController.php
+++ b/app/Http/Controllers/Api/Client/Servers/StartupController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\EggVariableData;
 use App\Exceptions\Model\DataValidationException;
 use App\Facades\Activity;
 use App\Http\Controllers\Api\Client\ClientApiController;
@@ -10,7 +11,6 @@ use App\Http\Requests\Api\Client\Servers\Startup\UpdateStartupVariableRequest;
 use App\Models\Server;
 use App\Models\ServerVariable;
 use App\Services\Servers\StartupCommandService;
-use App\Transformers\Api\Client\EggVariableTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Validation\ValidationException;
 use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
@@ -38,10 +38,10 @@ class StartupController extends ClientApiController
     {
         $startup = $this->startupCommandService->handle($server);
 
-        return $this->fractal->collection(
+        return $this->response->collection(
             $server->variables()->where('user_viewable', true)->orderBy('sort')->get()
         )
-            ->transformWith($this->getTransformer(EggVariableTransformer::class))
+            ->transformWith(EggVariableData::class)
             ->addMeta([
                 'startup_command' => $startup,
                 'docker_images' => $server->egg->docker_images,
@@ -96,8 +96,8 @@ class StartupController extends ClientApiController
                 ->log();
         }
 
-        return $this->fractal->item($variable)
-            ->transformWith($this->getTransformer(EggVariableTransformer::class))
+        return $this->response->item($variable)
+            ->transformWith(EggVariableData::class)
             ->addMeta([
                 'startup_command' => $startup,
                 'raw_startup_command' => $server->startup,

--- a/app/Http/Controllers/Api/Client/Servers/SubuserController.php
+++ b/app/Http/Controllers/Api/Client/Servers/SubuserController.php
@@ -2,6 +2,7 @@
 
 namespace App\Http\Controllers\Api\Client\Servers;
 
+use App\Data\Api\Client\SubuserData;
 use App\Enums\SubuserPermission;
 use App\Exceptions\Model\DataValidationException;
 use App\Exceptions\Service\Subuser\ServerSubuserExistsException;
@@ -18,7 +19,6 @@ use App\Models\User;
 use App\Services\Subusers\SubuserCreationService;
 use App\Services\Subusers\SubuserDeletionService;
 use App\Services\Subusers\SubuserUpdateService;
-use App\Transformers\Api\Client\SubuserTransformer;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Http\Request;
@@ -47,8 +47,8 @@ class SubuserController extends ClientApiController
      */
     public function index(GetSubuserRequest $request, Server $server): array
     {
-        return $this->fractal->collection($server->subusers)
-            ->transformWith($this->getTransformer(SubuserTransformer::class))
+        return $this->response->collection($server->subusers)
+            ->transformWith(SubuserData::class)
             ->toArray();
     }
 
@@ -63,8 +63,8 @@ class SubuserController extends ClientApiController
     {
         $subuser = $request->attributes->get('subuser');
 
-        return $this->fractal->item($subuser)
-            ->transformWith($this->getTransformer(SubuserTransformer::class))
+        return $this->response->item($subuser)
+            ->transformWith(SubuserData::class)
             ->toArray();
     }
 
@@ -92,8 +92,8 @@ class SubuserController extends ClientApiController
             ->property(['email' => $email, 'permissions' => $subuser->permissions])
             ->log();
 
-        return $this->fractal->item($subuser)
-            ->transformWith($this->getTransformer(SubuserTransformer::class))
+        return $this->response->item($subuser)
+            ->transformWith(SubuserData::class)
             ->toArray();
     }
 
@@ -113,8 +113,8 @@ class SubuserController extends ClientApiController
 
         $this->updateService->handle($subuser, $server, $this->getCleanedPermissions($request));
 
-        return $this->fractal->item($subuser->refresh())
-            ->transformWith($this->getTransformer(SubuserTransformer::class))
+        return $this->response->item($subuser->refresh())
+            ->transformWith(SubuserData::class)
             ->toArray();
     }
 


### PR DESCRIPTION
Second layer of the API freeze stack, on top of #2520. This replaces the League Fractal transformer pipeline with laravel-data backed wire objects behind an envelope layer we own. The old transformers and Fractal extensions stay in place untouched so the next layer can delete them in one sweep.

### How to review this (65 files, +2444/-210)

The diff splits into three buckets that need very different levels of attention.

**1. The envelope layer, `app/Data/Api/` core (4 files, ~450 lines): read closely**

This is where the risk lives:

- `ApiResource.php` is the laravel-data base class for all wire objects
- `Envelope.php` renders the panel's `{object, attributes}` format with includes nested under `relationships`
- `IncludeContext.php` carries the request and include paths along with the authorize checks ported from the transformers
- `PanelResponse.php` is a drop-in for the injected Fractal wrapper: it reproduces League's include parsing, recursion trimming, the pagination block with its empty `links` object, and Fractalistic's `addMeta` union semantics

**2. Wire objects (30 files): spot-check**

One Data class per existing transformer, 15 application and 15 client. Each is a field-for-field port, and the deliberate transformer quirks are preserved exactly: the egg variable resource key mismatch, the plural `databases` include key, and the deprecated duplicate payload fields. Picking two or three and diffing them against their old transformer is the right sampling strategy; the snapshot suite below covers the rest.

**3. Controller call sites (31 files): mechanical, skim for pattern breaks**

Every call site changes the same way:

```diff
- return $this->fractal->collection($request->user()->sshKeys)
-     ->transformWith($this->getTransformer(UserSSHKeyTransformer::class))
+ return $this->response->collection($request->user()->sshKeys)
+     ->transformWith(UserSSHKeyData::class)
      ->toArray();
```

### Proof

The contract freeze suite from #2520 is the point of the stack: all 75 response snapshots pass with zero changes, and the pre-existing application and client Integration suites stay green.

### Behavior change (one, deliberate)

The egg `config` and `script` includes and the server `transfer` include were declared but never implemented, so requesting them used to 500. They are now silently ignored like any other unknown include.
