### PR TITLE
Remove the deprecated request input aliases

### DIFF
--- a/app/Http/Controllers/Api/Application/Nodes/NodeDeploymentController.php
+++ b/app/Http/Controllers/Api/Application/Nodes/NodeDeploymentController.php
@@ -33,7 +33,7 @@ class NodeDeploymentController extends ApplicationApiController
             $data['memory'] ?? 0,
             $data['disk'] ?? 0,
             $data['cpu'] ?? 0,
-            $data['tags'] ?? $data['location_ids'] ?? [],
+            $data['tags'] ?? [],
         );
 
         return $this->fractal->collection($nodes)

--- a/app/Http/Requests/Api/Application/Nodes/GetDeployableNodesRequest.php
+++ b/app/Http/Requests/Api/Application/Nodes/GetDeployableNodesRequest.php
@@ -17,13 +17,6 @@ class GetDeployableNodesRequest extends GetNodesRequest
             'cpu' => 'sometimes|integer|min:0',
             /** Only return nodes carrying all of these tags. */
             'tags' => 'sometimes|array',
-
-            /**
-             * Only return nodes in these locations.
-             *
-             * @deprecated Use `tags` instead.
-             */
-            'location_ids' => 'sometimes|array',
         ];
     }
 }

--- a/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/StoreServerRequest.php
@@ -76,18 +76,6 @@ class StoreServerRequest extends ApplicationApiRequest
 
             /** Ask the Panel to pick a node and allocation instead of naming one in `allocation`. */
             'deploy' => 'sometimes|required|array',
-            /**
-             * IDs of the locations the server may be deployed to.
-             *
-             * @deprecated Use `deploy.tags` instead.
-             */
-            'deploy.locations' => 'sometimes|array',
-            /**
-             * ID of a location the server may be deployed to.
-             *
-             * @deprecated Use `deploy.tags` instead.
-             */
-            'deploy.locations.*' => 'required_with:deploy.locations|integer|min:1',
             /** Only deploy to nodes carrying all of these tags. */
             'deploy.tags' => 'array',
             /** A tag the destination node has to carry. */
@@ -186,11 +174,6 @@ class StoreServerRequest extends ApplicationApiRequest
             return !$input->deploy;
         });
 
-        /** @deprecated use tags instead */
-        $validator->sometimes('deploy.locations', 'present', function ($input) {
-            return $input->deploy;
-        });
-
         $validator->sometimes('deploy.tags', 'present', function ($input) {
             return $input->deploy;
         });
@@ -211,7 +194,7 @@ class StoreServerRequest extends ApplicationApiRequest
 
         $object = new DeploymentObject();
         $object->setDedicated($this->input('deploy.dedicated_ip', false));
-        $object->setTags($this->input('deploy.tags', $this->input('deploy.locations', [])));
+        $object->setTags($this->input('deploy.tags', []));
         $object->setPorts($this->input('deploy.port_range', []));
 
         return $object;

--- a/app/Http/Requests/Api/Application/Servers/UpdateServerBuildConfigurationRequest.php
+++ b/app/Http/Requests/Api/Application/Servers/UpdateServerBuildConfigurationRequest.php
@@ -23,30 +23,17 @@ class UpdateServerBuildConfigurationRequest extends ServerWriteRequest
             /** Resource limits applied to the server's container. */
             'limits' => 'sometimes|array',
             /** Memory the server may use, in MiB. Use `0` for unlimited. */
-            'limits.memory' => $this->requiredToOptional('memory', $rules['memory'], true),
+            'limits.memory' => $this->requiredToOptional($rules['memory']),
             /** Swap the server may use, in MiB. Use `0` to disable swap and `-1` for unlimited. */
-            'limits.swap' => $this->requiredToOptional('swap', $rules['swap'], true),
+            'limits.swap' => $this->requiredToOptional($rules['swap']),
             /** Block IO weight of the container relative to other containers on the node. */
-            'limits.io' => $this->requiredToOptional('io', $rules['io'], true),
+            'limits.io' => $this->requiredToOptional($rules['io']),
             /** CPU the server may use, where each 100 is one core. Use `0` for unlimited. */
-            'limits.cpu' => $this->requiredToOptional('cpu', $rules['cpu'], true),
+            'limits.cpu' => $this->requiredToOptional($rules['cpu']),
             /** Physical CPU threads the container is pinned to, such as `0`, `0-2` or `0,2`. */
-            'limits.threads' => $this->requiredToOptional('threads', $rules['threads'], true),
+            'limits.threads' => $this->requiredToOptional($rules['threads']),
             /** Disk space the server may use, in MiB. Use `0` for unlimited. */
-            'limits.disk' => $this->requiredToOptional('disk', $rules['disk'], true),
-
-            /** @deprecated Use `limits.memory` instead. */
-            'memory' => $this->requiredToOptional('memory', $rules['memory']),
-            /** @deprecated Use `limits.swap` instead. */
-            'swap' => $this->requiredToOptional('swap', $rules['swap']),
-            /** @deprecated Use `limits.io` instead. */
-            'io' => $this->requiredToOptional('io', $rules['io']),
-            /** @deprecated Use `limits.cpu` instead. */
-            'cpu' => $this->requiredToOptional('cpu', $rules['cpu']),
-            /** @deprecated Use `limits.threads` instead. */
-            'threads' => $this->requiredToOptional('threads', $rules['threads']),
-            /** @deprecated Use `limits.disk` instead. */
-            'disk' => $this->requiredToOptional('disk', $rules['disk']),
+            'limits.disk' => $this->requiredToOptional($rules['disk']),
 
             /** IDs of allocations to assign to the server on top of the ones it already has. */
             'add_allocations' => 'bail|array',
@@ -114,14 +101,13 @@ class UpdateServerBuildConfigurationRequest extends ServerWriteRequest
     }
 
     /**
-     * Converts existing rules for certain limits into a format that maintains backwards
-     * compatability with the old API endpoint while also supporting a more correct API
-     * call.
+     * Model rules mark these fields required, but on this endpoint they are only
+     * required when the limits block is present at all.
      *
      * @param  array<array-key, mixed>  $rules
      * @return array<array-key, string>
      */
-    protected function requiredToOptional(string $field, array $rules, bool $limits = false): array
+    protected function requiredToOptional(array $rules): array
     {
         if (!in_array('required', $rules)) {
             return $rules;
@@ -131,7 +117,7 @@ class UpdateServerBuildConfigurationRequest extends ServerWriteRequest
             ->filter(function ($value) {
                 return $value !== 'required';
             })
-            ->prepend($limits ? 'required_with:limits' : 'required_without:limits')
+            ->prepend('required_with:limits')
             ->toArray();
     }
 }

--- a/tests/Feature/ApiDocumentationTest.php
+++ b/tests/Feature/ApiDocumentationTest.php
@@ -67,8 +67,8 @@ it('describes request body fields from the rules they belong to', function () {
         ->toBe('Memory the server may use, in MiB. Use `0` for unlimited.')
         // Descriptions given as attributes, for rules that come straight off a model.
         ->and($schemas['StoreUserRequest']['properties']['email']['description'])->not->toBeEmpty()
-        // @deprecated on a rule marks the field rather than only reading as prose.
-        ->and($schemas['UpdateServerBuildConfigurationRequest']['properties']['memory']['deprecated'])->toBeTrue();
+        // The deprecated flat build fields are gone entirely, not merely marked.
+        ->and($schemas['UpdateServerBuildConfigurationRequest']['properties'])->not->toHaveKey('memory');
 });
 
 it('leaves operation descriptions as they are written in the controller', function () {

--- a/tests/Integration/Api/Application/DeprecatedRequestAliasRemovalTest.php
+++ b/tests/Integration/Api/Application/DeprecatedRequestAliasRemovalTest.php
@@ -1,0 +1,105 @@
+<?php
+
+namespace App\Tests\Integration\Api\Application;
+
+use App\Models\Egg;
+use App\Models\Node;
+use Illuminate\Support\Facades\Http;
+
+/**
+ * The deprecated request input aliases (deploy.locations on server creation, the
+ * flat build limit fields, and location_ids on deployable nodes) are removed for
+ * 1.0. Clients still sending them get standard unknown-field treatment: the input
+ * is ignored and only the canonical fields drive behavior.
+ */
+class DeprecatedRequestAliasRemovalTest extends ApplicationApiIntegrationTestCase
+{
+    public function test_deploy_locations_no_longer_satisfies_the_deploy_block(): void
+    {
+        $payload = [
+            'name' => 'Alias Removal Server',
+            'user' => $this->getApiUser()->id,
+            'egg' => Egg::query()->where('name', 'Bungeecord')->firstOrFail()->id,
+            'docker_image' => 'ghcr.io/example/java:21',
+            'startup' => 'java -jar server.jar',
+            'environment' => [],
+            'limits' => ['memory' => 128, 'swap' => 0, 'disk' => 512, 'io' => 500, 'cpu' => 100],
+            'feature_limits' => ['databases' => 0, 'allocations' => 0, 'backups' => 0],
+            'deploy' => [
+                'locations' => [1],
+                'dedicated_ip' => false,
+                'port_range' => [],
+            ],
+        ];
+
+        $withLocations = $this->postJson('/api/application/servers', $payload)->assertUnprocessable();
+
+        unset($payload['deploy']['locations']);
+        $withoutDeprecatedField = $this->postJson('/api/application/servers', $payload)->assertUnprocessable();
+
+        // Both requests fail for the same reason, the missing deploy.tags block, and
+        // the removed field neither satisfies the deploy requirements nor produces an
+        // error of its own.
+        $this->assertSame($withoutDeprecatedField->json('errors'), $withLocations->json('errors'));
+        $this->assertStringContainsString('deploy.tags', json_encode($withLocations->json('errors')));
+        $this->assertStringNotContainsString('locations', json_encode($withLocations->json('errors')));
+    }
+
+    public function test_flat_build_limit_fields_are_ignored(): void
+    {
+        Http::fake();
+
+        $server = $this->createServerModel();
+
+        $response = $this->patchJson("/api/application/servers/{$server->id}/build", [
+            'allocation' => $server->allocation_id,
+            'memory' => 9999,
+            'swap' => 9999,
+            'io' => 999,
+            'cpu' => 999,
+            'threads' => null,
+            'disk' => 9999,
+            'feature_limits' => [
+                'databases' => $server->database_limit,
+                'allocations' => $server->allocation_limit,
+                'backups' => $server->backup_limit,
+            ],
+        ]);
+
+        $response->assertOk();
+
+        // The flat fields used to update the build; now only limits.* does.
+        $this->assertSame($server->memory, $server->fresh()->memory);
+        $this->assertSame($server->disk, $server->fresh()->disk);
+
+        $this->patchJson("/api/application/servers/{$server->id}/build", [
+            'allocation' => $server->allocation_id,
+            'limits' => ['memory' => 256, 'swap' => 0, 'io' => 500, 'cpu' => 0, 'threads' => null, 'disk' => 1024],
+            'feature_limits' => [
+                'databases' => $server->database_limit,
+                'allocations' => $server->allocation_limit,
+                'backups' => $server->backup_limit,
+            ],
+        ])->assertOk();
+
+        $this->assertSame(256, $server->fresh()->memory);
+        $this->assertSame(1024, $server->fresh()->disk);
+    }
+
+    public function test_location_ids_no_longer_filters_deployable_nodes(): void
+    {
+        $tagged = Node::factory()->create(['tags' => ['alias-removal']]);
+        $untagged = Node::factory()->create();
+
+        $unfiltered = $this->getJson('/api/application/nodes/deployable?memory=64&disk=64&location_ids[]=999999');
+        $unfiltered->assertOk();
+        $this->assertEqualsCanonicalizing(
+            [$tagged->id, $untagged->id],
+            collect($unfiltered->json('data'))->pluck('attributes.id')->all(),
+        );
+
+        $filtered = $this->getJson('/api/application/nodes/deployable?memory=64&disk=64&tags[]=alias-removal');
+        $filtered->assertOk();
+        $this->assertSame([$tagged->id], collect($filtered->json('data'))->pluck('attributes.id')->all());
+    }
+}


### PR DESCRIPTION
Part of the API freeze for 1.0, though independent of the transformer stack. This removes the three deprecated request input aliases as a hard break: deploy.locations on server creation (rules, the withValidator presence rule, and the getDeploymentObject fallback), the six flat build limit fields on the build endpoint together with the dead required_without branch of requiredToOptional, and location_ids on the deployable nodes endpoint. Fields removed from validation get Laravel's normal unknown-input treatment, so old clients are ignored rather than rejected, and the canonical deploy.tags and limits.* inputs are the only ones that drive behavior now.

Covered by a new DeprecatedRequestAliasRemovalTest: a deploy block carrying only locations fails identically to an empty deploy block without any mention of locations, flat build fields leave the server untouched while limits.* still updates it, and location_ids no longer filters deployable nodes while tags still does. The api docs test's deprecated-field assertion now checks the flat memory field is gone entirely, since these were the last deprecated request fields in the codebase.
