### PR TITLE
Validate the generated OpenAPI specs in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -6,6 +6,9 @@ on:
       - main
   pull_request:
 
+permissions:
+  contents: read
+
 env:
   APP_ENV: testing
   APP_DEBUG: "false"

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -313,7 +313,7 @@ jobs:
         if: env.COMPOSER_AUTH != ''
         run: |
           composer config repositories.dedoc composer https://satis.dedoc.co
-          composer require dedoc/scramble-pro --no-interaction --no-progress --no-scripts
+          composer require dedoc/scramble-pro:0.9.15 --no-interaction --no-progress --no-scripts
 
       - name: Create SQLite file
         run: touch database/testing.sqlite
@@ -336,7 +336,7 @@ jobs:
           done
 
       - name: Lint specs
-        run: npx --yes @redocly/cli lint application-openapi.json client-openapi.json
+        run: npx --yes @redocly/cli@2.47.0 lint application-openapi.json client-openapi.json
 
       - name: Upload specs
         uses: actions/upload-artifact@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -267,3 +267,78 @@ jobs:
 
       - name: Integration tests
         run: vendor/bin/pest tests/Integration --parallel --do-not-fail-on-phpunit-warning
+
+  openapi:
+    name: OpenAPI
+    runs-on: ubuntu-latest
+    env:
+      DB_CONNECTION: sqlite
+      DB_DATABASE: testing.sqlite
+      COMPOSER_AUTH: ${{ secrets.COMPOSER_AUTH }}
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+
+      - name: Get cache directory
+        id: composer-cache
+        run: |
+          echo "dir=$(composer config cache-files-dir)" >> $GITHUB_OUTPUT
+
+      - name: Cache
+        uses: actions/cache@v5
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-composer-8.4-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-composer-8.4-
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.4
+          extensions: bcmath, curl, gd, mbstring, mysql, openssl, pdo, tokenizer, xml, zip
+          tools: composer:v2
+          coverage: none
+
+      - name: Install dependencies
+        run: composer install --no-interaction --no-suggest --no-progress --no-scripts
+
+      # Scramble Pro adds native laravel-data schema inference. The satis credentials
+      # live in the COMPOSER_AUTH secret, so fork PRs skip this step and the job still
+      # exports and lints with the free package.
+      - name: Install Scramble Pro
+        if: env.COMPOSER_AUTH != ''
+        run: |
+          composer config repositories.dedoc composer https://satis.dedoc.co
+          composer require dedoc/scramble-pro --no-interaction --no-progress --no-scripts
+
+      - name: Create SQLite file
+        run: touch database/testing.sqlite
+
+      - name: Run Migrations
+        run: php artisan migrate --force --seed
+
+      - name: Export OpenAPI specs
+        run: |
+          php artisan scramble:export --api=application --path=application-openapi.json
+          php artisan scramble:export --api=client --path=client-openapi.json
+
+      # Scramble emits the additionalItems keyword, which JSON Schema 2020-12 dropped,
+      # so the raw export fails structural validation.
+      - name: Normalize specs
+        run: |
+          for f in application-openapi.json client-openapi.json; do
+            jq 'walk(if type == "object" then del(.additionalItems) else . end)' "$f" > "$f.tmp"
+            mv "$f.tmp" "$f"
+          done
+
+      - name: Lint specs
+        run: npx --yes @redocly/cli lint application-openapi.json client-openapi.json
+
+      - name: Upload specs
+        uses: actions/upload-artifact@v4
+        with:
+          name: openapi-specs
+          path: |
+            application-openapi.json
+            client-openapi.json


### PR DESCRIPTION
Part of the API freeze for 1.0. The generated OpenAPI documents become a validated artifact instead of a runtime-only byproduct: a new CI job exports both API specs, normalizes away the additionalItems keyword Scramble still emits even though JSON Schema 2020-12 dropped it, lints them with redocly's recommended ruleset, and uploads application-openapi.json and client-openapi.json as artifacts for the docs repo to consume. Any change that makes a spec structurally invalid now fails the build.

Scramble Pro installs at job time from the dedoc satis repository when the COMPOSER_AUTH secret is present, so the license never touches composer.json and contributors keep a credential-free install; fork PRs skip that step and still run the export and lint gate on free Scramble. One setup step for you: create the COMPOSER_AUTH repository secret containing the http-basic JSON for satis.dedoc.co with your license key as the password. Verified locally by exporting both specs, running the jq normalization, and getting a clean redocly lint with 30 advisory warnings (missing tag descriptions and the like) and zero errors.
