### PR TITLE
Point contributors at the API versioning policy

### DIFF
--- a/api-versioning.md
+++ b/api-versioning.md
@@ -1,0 +1,7 @@
+# API Versioning
+
+The Panel's HTTP API is unversioned and carries a non-breaking guarantee: from 1.0 onward, a response field, envelope shape, or accepted request input only changes in ways existing API clients can ignore. New fields and endpoints may appear at any time, but nothing an existing client depends on is renamed, removed, or retyped.
+
+Two things in this repository define that frozen contract. The generated OpenAPI documents for the application and client APIs are exported and validated in CI, and the response snapshot suite under `tests/Integration/Api/ContractFreeze` records the exact JSON every endpoint returns. Any change that alters one of those snapshots or the exported specs is a breaking API change and should be treated as such in review, regardless of how small the diff looks.
+
+The full versioning policy, including how deprecations are announced and how long deprecated payload fields stick around, lives in the [Pelican documentation](https://pelican.dev/docs).

--- a/api-versioning.md
+++ b/api-versioning.md
@@ -2,6 +2,6 @@
 
 The Panel's HTTP API is unversioned and carries a non-breaking guarantee: from 1.0 onward, a response field, envelope shape, or accepted request input only changes in ways existing API clients can ignore. New fields and endpoints may appear at any time, but nothing an existing client depends on is renamed, removed, or retyped.
 
-Two things in this repository define that frozen contract. The generated OpenAPI documents for the application and client APIs are exported and validated in CI, and the response snapshot suite under `tests/Integration/Api/ContractFreeze` records the exact JSON every endpoint returns. Any change that alters one of those snapshots or the exported specs is a breaking API change and should be treated as such in review, regardless of how small the diff looks.
+Two things in this repository define that guarantee. The generated OpenAPI documents for the application and client APIs are exported and validated in CI, and the test fixture suite under `tests/Integration/Api/Fixtures` records the exact JSON every endpoint returns. Any change that alters one of those snapshots or the exported specs is a breaking API change and should be treated as such in review, regardless of how small the diff looks.
 
 The full versioning policy, including how deprecations are announced and how long deprecated payload fields stick around, lives in the [Pelican documentation](https://pelican.dev/docs).

--- a/contributing.md
+++ b/contributing.md
@@ -42,6 +42,10 @@ Also, please make sure that your pull requests are as targeted and simple as pos
 If you add any new translation strings make sure to only add them to english.  
 Other languages are translated via [Crowdin](https://crowdin.com/project/pelican-dev).
 
+### API changes
+
+The HTTP API is a frozen contract; see [api-versioning.md](./api-versioning.md) before changing anything a response returns or a request accepts.
+
 ## Code Review Process
 
 Your pull request will then be reviewed by the maintainers.  

--- a/contributing.md
+++ b/contributing.md
@@ -44,7 +44,7 @@ Other languages are translated via [Crowdin](https://crowdin.com/project/pelican
 
 ### API changes
 
-The HTTP API is a frozen contract; see [api-versioning.md](./api-versioning.md) before changing anything a response returns or a request accepts.
+The HTTP API is frozen for 1.0; see [api-versioning.md](./api-versioning.md) before changing anything a response returns or a request accepts.
 
 ## Code Review Process
 


### PR DESCRIPTION
Last piece of the 1.0 API contract freeze work in this repo. A short api-versioning.md states the commitment: the API is unversioned with a non-breaking guarantee, the frozen contract is defined by the exported OpenAPI specs and the ContractFreeze snapshot suite, and any change that alters either is a breaking API change no matter how small the diff. contributing.md gains a pointer so it comes up in review. The fuller policy text, deprecation windows and announcement process, belongs in the external docs and is linked rather than duplicated here.