### PR TITLE
Fix configured database defaults in installer

### DIFF
--- a/app/Livewire/Installer/Steps/DatabaseStep.php
+++ b/app/Livewire/Installer/Steps/DatabaseStep.php
@@ -81,7 +81,11 @@ class DatabaseStep
                     ->minValue(1)
                     ->maxValue(65535)
                     ->required(fn (Get $get) => $get('env_database.DB_CONNECTION') !== 'sqlite')
-                    ->default(fn (Get $get) => self::getConnectionDefault($get, 'port', '3306'))
+                    ->default(fn (Get $get) => self::getConnectionDefault(
+                        $get,
+                        'port',
+                        $get('env_database.DB_CONNECTION') === 'pgsql' ? '5432' : '3306',
+                    ))
                     ->hidden(fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite'),
                 TextInput::make('env_database.DB_USERNAME')
                     ->label(trans('installer.database.fields.username'))
@@ -132,10 +136,7 @@ class DatabaseStep
             return true;
         }
 
-        $configuredPassword = config("database.connections.{$driver}.password");
-        if ($password === null && $driver === config('database.default') && is_string($configuredPassword)) {
-            $password = $configuredPassword;
-        }
+        $password = self::getConnectionPassword($driver, $password);
 
         try {
             config()->set('database.connections._panel_install_test', [
@@ -163,5 +164,15 @@ class DatabaseStep
         }
 
         return true;
+    }
+
+    private static function getConnectionPassword(string $driver, ?string $password): ?string
+    {
+        $configuredPassword = config("database.connections.{$driver}.password");
+        if (($password === null || $password === '') && $driver === config('database.default') && is_string($configuredPassword)) {
+            return $configuredPassword;
+        }
+
+        return $password;
     }
 }

--- a/app/Livewire/Installer/Steps/DatabaseStep.php
+++ b/app/Livewire/Installer/Steps/DatabaseStep.php
@@ -38,7 +38,7 @@ class DatabaseStep
                     ->default(config('database.default'))
                     ->live()
                     ->afterStateUpdated(function ($state, Set $set, Get $get) {
-                        $set('env_database.DB_DATABASE', $state === 'sqlite' ? 'database.sqlite' : 'panel');
+                        $set('env_database.DB_DATABASE', self::getConfiguredConnectionValue($state, 'database', 'panel'));
 
                         switch ($state) {
                             case 'sqlite':
@@ -49,14 +49,14 @@ class DatabaseStep
                                 break;
                             case 'mariadb':
                             case 'mysql':
-                                $set('env_database.DB_HOST', $get('env_database.DB_HOST') ?? '127.0.0.1');
-                                $set('env_database.DB_USERNAME', $get('env_database.DB_USERNAME') ?? 'pelican');
-                                $set('env_database.DB_PORT', '3306');
+                                $set('env_database.DB_HOST', $get('env_database.DB_HOST') ?? self::getConfiguredConnectionValue($state, 'host', '127.0.0.1'));
+                                $set('env_database.DB_USERNAME', $get('env_database.DB_USERNAME') ?? self::getConfiguredConnectionValue($state, 'username', 'pelican'));
+                                $set('env_database.DB_PORT', self::getConfiguredConnectionValue($state, 'port', '3306'));
                                 break;
                             case 'pgsql':
-                                $set('env_database.DB_HOST', $get('env_database.DB_HOST') ?? '127.0.0.1');
-                                $set('env_database.DB_USERNAME', $get('env_database.DB_USERNAME') ?? 'pelican');
-                                $set('env_database.DB_PORT', '5432');
+                                $set('env_database.DB_HOST', $get('env_database.DB_HOST') ?? self::getConfiguredConnectionValue($state, 'host', '127.0.0.1'));
+                                $set('env_database.DB_USERNAME', $get('env_database.DB_USERNAME') ?? self::getConfiguredConnectionValue($state, 'username', 'pelican'));
+                                $set('env_database.DB_PORT', self::getConfiguredConnectionValue($state, 'port', '5432'));
                                 break;
                         }
                     }),
@@ -65,12 +65,13 @@ class DatabaseStep
                     ->placeholder(fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite' ? 'database.sqlite' : 'panel')
                     ->hintIcon(TablerIcon::QuestionMark, fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite' ? trans('installer.database.fields.path_help') : trans('installer.database.fields.name_help'))
                     ->required()
-                    ->default('database.sqlite'),
+                    ->default(fn (Get $get) => self::getConnectionDefault($get, 'database', 'panel')),
                 TextInput::make('env_database.DB_HOST')
                     ->label(trans('installer.database.fields.host'))
                     ->placeholder('127.0.0.1')
                     ->hintIcon(TablerIcon::QuestionMark, trans('installer.database.fields.host_help'))
                     ->required(fn (Get $get) => $get('env_database.DB_CONNECTION') !== 'sqlite')
+                    ->default(fn (Get $get) => self::getConnectionDefault($get, 'host', '127.0.0.1'))
                     ->hidden(fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite'),
                 TextInput::make('env_database.DB_PORT')
                     ->label(trans('installer.database.fields.port'))
@@ -80,12 +81,14 @@ class DatabaseStep
                     ->minValue(1)
                     ->maxValue(65535)
                     ->required(fn (Get $get) => $get('env_database.DB_CONNECTION') !== 'sqlite')
+                    ->default(fn (Get $get) => self::getConnectionDefault($get, 'port', '3306'))
                     ->hidden(fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite'),
                 TextInput::make('env_database.DB_USERNAME')
                     ->label(trans('installer.database.fields.username'))
                     ->placeholder('pelican')
                     ->hintIcon(TablerIcon::QuestionMark, trans('installer.database.fields.username_help'))
                     ->required(fn (Get $get) => $get('env_database.DB_CONNECTION') !== 'sqlite')
+                    ->default(fn (Get $get) => self::getConnectionDefault($get, 'username', 'pelican'))
                     ->hidden(fn (Get $get) => $get('env_database.DB_CONNECTION') === 'sqlite'),
                 TextInput::make('env_database.DB_PASSWORD')
                     ->label(trans('installer.database.fields.password'))
@@ -103,10 +106,35 @@ class DatabaseStep
             });
     }
 
+    private static function getConnectionDefault(Get $get, string $key, mixed $fallback): mixed
+    {
+        $driver = $get('env_database.DB_CONNECTION');
+
+        return self::getConfiguredConnectionValue($driver, $key, $fallback);
+    }
+
+    private static function getConfiguredConnectionValue(mixed $driver, string $key, mixed $fallback): mixed
+    {
+        if ($driver === 'sqlite') {
+            return $key === 'database' ? 'database.sqlite' : null;
+        }
+
+        if (!is_string($driver) || $driver !== config('database.default')) {
+            return $fallback;
+        }
+
+        return config("database.connections.{$driver}.{$key}", $fallback);
+    }
+
     private static function testConnection(string $driver, ?string $host, null|string|int $port, ?string $database, ?string $username, ?string $password): bool
     {
         if ($driver === 'sqlite') {
             return true;
+        }
+
+        $configuredPassword = config("database.connections.{$driver}.password");
+        if ($password === null && $driver === config('database.default') && is_string($configuredPassword)) {
+            $password = $configuredPassword;
         }
 
         try {

--- a/tests/Integration/Installer/PanelInstallerTest.php
+++ b/tests/Integration/Installer/PanelInstallerTest.php
@@ -3,8 +3,10 @@
 namespace App\Tests\Integration\Installer;
 
 use App\Livewire\Installer\PanelInstaller;
+use App\Livewire\Installer\Steps\DatabaseStep;
 use App\Tests\Integration\IntegrationTestCase;
 use Livewire\Livewire;
+use ReflectionMethod;
 
 class PanelInstallerTest extends IntegrationTestCase
 {
@@ -59,5 +61,34 @@ class PanelInstallerTest extends IntegrationTestCase
             ->assertSet('data.env_database.DB_PASSWORD', null);
 
         $component->assertSuccessful();
+    }
+
+    public function test_postgresql_uses_its_default_port_when_no_port_is_configured(): void
+    {
+        config()->set('app.installed', false);
+        config()->set('database.default', 'pgsql');
+        config()->set('database.connections.pgsql', [
+            'driver' => 'pgsql',
+            'host' => 'pelican-db',
+            'database' => 'pelican',
+            'username' => 'pelican-user',
+            'password' => 'pelican-password',
+        ]);
+
+        Livewire::test(PanelInstaller::class)
+            ->assertSet('data.env_database.DB_CONNECTION', 'pgsql')
+            ->assertSet('data.env_database.DB_PORT', '5432')
+            ->assertSuccessful();
+    }
+
+    public function test_empty_database_password_uses_the_configured_password(): void
+    {
+        config()->set('database.default', 'mariadb');
+        config()->set('database.connections.mariadb.password', 'pelican-password');
+
+        $resolver = new ReflectionMethod(DatabaseStep::class, 'getConnectionPassword');
+
+        $this->assertSame('pelican-password', $resolver->invoke(null, 'mariadb', ''));
+        $this->assertSame('entered-password', $resolver->invoke(null, 'mariadb', 'entered-password'));
     }
 }

--- a/tests/Integration/Installer/PanelInstallerTest.php
+++ b/tests/Integration/Installer/PanelInstallerTest.php
@@ -53,6 +53,11 @@ class PanelInstallerTest extends IntegrationTestCase
 
         $component
             ->set('data.env_database.DB_CONNECTION', 'sqlite')
+            ->assertSet('data.env_database.DB_DATABASE', 'database.sqlite')
+            ->assertSet('data.env_database.DB_HOST', null)
+            ->assertSet('data.env_database.DB_PORT', null)
+            ->assertSet('data.env_database.DB_USERNAME', null)
+            ->assertSet('data.env_database.DB_PASSWORD', null)
             ->set('data.env_database.DB_CONNECTION', 'mariadb')
             ->assertSet('data.env_database.DB_HOST', 'pelican-db')
             ->assertSet('data.env_database.DB_PORT', '3307')
@@ -89,6 +94,7 @@ class PanelInstallerTest extends IntegrationTestCase
         $resolver = new ReflectionMethod(DatabaseStep::class, 'getConnectionPassword');
 
         $this->assertSame('pelican-password', $resolver->invoke(null, 'mariadb', ''));
+        $this->assertSame('pelican-password', $resolver->invoke(null, 'mariadb', null));
         $this->assertSame('entered-password', $resolver->invoke(null, 'mariadb', 'entered-password'));
     }
 }

--- a/tests/Integration/Installer/PanelInstallerTest.php
+++ b/tests/Integration/Installer/PanelInstallerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Tests\Integration\Installer;
+
+use App\Livewire\Installer\PanelInstaller;
+use App\Tests\Integration\IntegrationTestCase;
+use Livewire\Livewire;
+
+class PanelInstallerTest extends IntegrationTestCase
+{
+    public function test_sqlite_defaults_remain_relative_and_do_not_include_connection_fields(): void
+    {
+        config()->set('app.installed', false);
+        config()->set('database.default', 'sqlite');
+
+        $component = Livewire::test(PanelInstaller::class);
+
+        $component
+            ->assertSet('data.env_database.DB_CONNECTION', 'sqlite')
+            ->assertSet('data.env_database.DB_DATABASE', 'database.sqlite')
+            ->assertSet('data.env_database.DB_HOST', null)
+            ->assertSet('data.env_database.DB_PORT', null)
+            ->assertSet('data.env_database.DB_USERNAME', null)
+            ->assertSet('data.env_database.DB_PASSWORD', null);
+
+        $component->assertSuccessful();
+    }
+
+    public function test_database_fields_are_hydrated_from_a_preconfigured_non_sqlite_connection(): void
+    {
+        config()->set('app.installed', false);
+        config()->set('database.default', 'mariadb');
+        config()->set('database.connections.mariadb', [
+            'driver' => 'mariadb',
+            'host' => 'pelican-db',
+            'port' => '3307',
+            'database' => 'pelican',
+            'username' => 'pelican-user',
+            'password' => 'pelican-password',
+        ]);
+
+        $component = Livewire::test(PanelInstaller::class);
+
+        $component
+            ->assertSet('data.env_database.DB_CONNECTION', 'mariadb')
+            ->assertSet('data.env_database.DB_HOST', 'pelican-db')
+            ->assertSet('data.env_database.DB_PORT', '3307')
+            ->assertSet('data.env_database.DB_DATABASE', 'pelican')
+            ->assertSet('data.env_database.DB_USERNAME', 'pelican-user')
+            ->assertSet('data.env_database.DB_PASSWORD', null);
+
+        $component
+            ->set('data.env_database.DB_CONNECTION', 'sqlite')
+            ->set('data.env_database.DB_CONNECTION', 'mariadb')
+            ->assertSet('data.env_database.DB_HOST', 'pelican-db')
+            ->assertSet('data.env_database.DB_PORT', '3307')
+            ->assertSet('data.env_database.DB_DATABASE', 'pelican')
+            ->assertSet('data.env_database.DB_USERNAME', 'pelican-user')
+            ->assertSet('data.env_database.DB_PASSWORD', null);
+
+        $component->assertSuccessful();
+    }
+}


### PR DESCRIPTION
## Summary

- hydrate the installer database fields from the configured default connection
- keep the password out of the form while reusing the configured password for connection validation
- preserve the existing SQLite defaults and clear irrelevant connection fields
- add integration coverage for SQLite and preconfigured non-SQLite connections

## Problem

On a fresh Docker installation with MariaDB configured as the default connection, the installer could visually select MariaDB while its related form state still used incomplete fallback values. This could make the first database validation fail unless the user switched drivers manually.

The database step now consistently reads the host, port, database, and username from the active configured connection during initial hydration and when the driver changes. If the password field is intentionally left blank, validation can use the already configured password without exposing it in the UI.

## Validation

- `php vendor/bin/pest tests/Integration/Installer/PanelInstallerTest.php` — 2 tests passed, 19 assertions
- `php vendor/bin/pint --test app/Livewire/Installer/Steps/DatabaseStep.php tests/Integration/Installer/PanelInstallerTest.php`
- completed a fresh Docker Desktop installation against MariaDB without toggling database drivers; migrations and administrator creation completed and the login page loaded successfully

Fixes #2245
