### PR TITLE
Register queue health monitoring

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -13,6 +13,7 @@ use App\Models\Webhook;
 use Illuminate\Console\Scheduling\Schedule;
 use Illuminate\Database\Console\PruneCommand;
 use Illuminate\Foundation\Console\Kernel as ConsoleKernel;
+use Spatie\Health\Commands\DispatchQueueCheckJobsCommand;
 use Spatie\Health\Commands\RunHealthChecksCommand;
 use Spatie\Health\Commands\ScheduleCheckHeartbeatCommand;
 
@@ -60,6 +61,7 @@ class Kernel extends ConsoleKernel
         }
 
         $schedule->command(ScheduleCheckHeartbeatCommand::class)->everyMinute();
+        $schedule->command(DispatchQueueCheckJobsCommand::class)->everyMinute();
         $schedule->command(RunHealthChecksCommand::class)->everyFiveMinutes();
     }
 }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -111,7 +111,7 @@ class AppServiceProvider extends ServiceProvider
                 EnvironmentCheck::new(),
                 CacheCheck::new(),
                 DatabaseCheck::new(),
-                QueueCheck::new()->failWhenHealthJobTakesLongerThanMinutes(5),
+                QueueCheck::new(),
                 ScheduleCheck::new(),
                 UsedDiskSpaceCheck::new(),
                 PanelVersionCheck::new(),

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -43,6 +43,7 @@ use Illuminate\Support\ServiceProvider;
 use Illuminate\Support\Str;
 use Laravel\Passkeys\Passkeys;
 use Laravel\Sanctum\Sanctum;
+use Spatie\Health\Checks\Checks\QueueCheck;
 use Spatie\Health\Facades\Health;
 
 class AppServiceProvider extends ServiceProvider
@@ -110,6 +111,7 @@ class AppServiceProvider extends ServiceProvider
                 EnvironmentCheck::new(),
                 CacheCheck::new(),
                 DatabaseCheck::new(),
+                QueueCheck::new()->failWhenHealthJobTakesLongerThanMinutes(5),
                 ScheduleCheck::new(),
                 UsedDiskSpaceCheck::new(),
                 PanelVersionCheck::new(),


### PR DESCRIPTION
## Summary

- register Spatie Health's `QueueCheck` with a five-minute failure threshold
- dispatch the queue-check heartbeat command every minute

## Why

Pelican already uses Spatie Health for application monitoring, but the queue worker check was not registered or scheduled. This adds the smallest complete integration so stalled queue processing is visible through the existing health system.

This is part (b) of the work split out from #2529 following maintainer review.

## Validation

- `vendor/bin/pint --test app/Console/Kernel.php app/Providers/AppServiceProvider.php`
- `vendor/bin/phpstan analyse --no-progress app/Console/Kernel.php app/Providers/AppServiceProvider.php`
- confirmed `health:queue-check-heartbeat` is registered by Artisan
- confirmed the heartbeat command appears in `php artisan schedule:list` every minute