### PR TITLE
Fix/wings server list latency

### DIFF
--- a/app/Filament/Admin/Resources/Servers/Pages/ListServers.php
+++ b/app/Filament/Admin/Resources/Servers/Pages/ListServers.php
@@ -16,6 +16,7 @@ use Filament\Actions\EditAction;
 use Filament\Resources\Pages\ListRecords;
 use Filament\Tables\Columns\SelectColumn;
 use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Columns\ViewColumn;
 use Filament\Tables\Grouping\Group;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
@@ -37,12 +38,9 @@ class ListServers extends ListRecords
                 Group::make('egg.name')->getDescriptionFromRecordUsing(fn (Server $server) => str($server->egg->description)->limit(150)),
             ])
             ->columns([
-                TextColumn::make('condition')
+                ViewColumn::make('condition')
                     ->label(trans('admin/server.condition'))
-                    ->default('unknown')
-                    ->badge()
-                    ->icon(fn (Server $server) => $server->condition->getIcon())
-                    ->color(fn (Server $server) => $server->condition->getColor()),
+                    ->view('livewire.columns.server-condition-column'),
                 TextColumn::make('uuid')
                     ->hidden()
                     ->label(trans('admin/server.uuid'))

--- a/app/Filament/App/Resources/Servers/Pages/ListServers.php
+++ b/app/Filament/App/Resources/Servers/Pages/ListServers.php
@@ -136,6 +136,7 @@ class ListServers extends ListRecords
         $defaultPerPage = in_array($storedPerPage, $pageOptions, true) ? $storedPerPage : ($usingGrid ? 10 : 20);
 
         return $table
+            ->deferLoading(!$usingGrid)
             ->paginated($pageOptions)
             ->defaultPaginationPageOption($defaultPerPage)
             ->query(fn () => $baseQuery)

--- a/app/Livewire/ServerCondition.php
+++ b/app/Livewire/ServerCondition.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace App\Livewire;
+
+use App\Models\Server;
+use Illuminate\View\View;
+use Livewire\Attributes\Locked;
+use Livewire\Component;
+
+class ServerCondition extends Component
+{
+    #[Locked]
+    public Server $server;
+
+    public function render(): View
+    {
+        return view('livewire.server-condition', [
+            'condition' => $this->server->condition,
+        ]);
+    }
+
+    public function placeholder(): View
+    {
+        return view('livewire.server-condition-placeholder');
+    }
+}

--- a/resources/views/livewire/columns/server-condition-column.blade.php
+++ b/resources/views/livewire/columns/server-condition-column.blade.php
@@ -1,0 +1,3 @@
+<div class="fi-ta-text fi-ta-text-has-badges">
+    @livewire('server-condition', ['server' => $record, 'lazy' => true], key('admin-server-condition-' . $record->getKey()))
+</div>

--- a/resources/views/livewire/server-condition-placeholder.blade.php
+++ b/resources/views/livewire/server-condition-placeholder.blade.php
@@ -1,0 +1,6 @@
+<x-filament::badge color="gray" size="sm">
+    <span class="inline-flex items-center gap-1">
+        <x-filament::loading-indicator class="h-3 w-3" />
+        {{ trans('server/dashboard.loading') }}
+    </span>
+</x-filament::badge>

--- a/resources/views/livewire/server-condition.blade.php
+++ b/resources/views/livewire/server-condition.blade.php
@@ -1,0 +1,3 @@
+<x-filament::badge :color="$condition->getColor()" :icon="$condition->getIcon()" size="sm">
+    {{ $condition->getLabel() }}
+</x-filament::badge>

--- a/resources/views/livewire/server-entry-placeholder.blade.php
+++ b/resources/views/livewire/server-entry-placeholder.blade.php
@@ -47,7 +47,7 @@
                     $cpuMax = \App\Enums\ServerResourceType::CPULimit->getResourceAmount($server) ?: 100;
                     $getState = fn() => $cpuCurrent;
                     $getMaxValue = fn() => $cpuMax;
-                    $getProgressLabel = fn () => $server->formatResource(App\Enums\ServerResourceType::CPU, 0) . ' / ' . $server->formatResource(App\Enums\ServerResourceType::CPULimit, 0);
+                    $getProgressLabel = fn () => format_number($cpuCurrent, precision: 0) . '% / ' . $server->formatResource(App\Enums\ServerResourceType::CPULimit, 0);
                 @endphp
 
                 @include('livewire.columns.progress-bar-column', [


### PR DESCRIPTION
## Summary

- Use the configured connect and request timeouts for Wings requests.
- Load admin server conditions after the database-backed rows render.
- Defer the user server table until after the initial page render.
- Keep grid placeholders from requesting Wings resources.

## Notes

Admin condition checks load independently for visible rows. The user table still resolves its server data in a deferred Livewire request.