### PR TITLE
Run the Filament tests in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -78,6 +78,12 @@ jobs:
         env:
           CREATE_SNAPSHOTS: "false"
 
+      # Panel/authorization tests, nothing database specific, so the sqlite job covers them.
+      - name: Filament tests
+        run: vendor/bin/pest tests/Filament --parallel --do-not-fail-on-phpunit-warning
+        env:
+          CREATE_SNAPSHOTS: "false"
+
   mysql:
     name: MySQL
     runs-on: ubuntu-latest

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -11,6 +11,9 @@
         <testsuite name="Unit">
             <directory>./tests/Unit</directory>
         </testsuite>
+        <testsuite name="Filament">
+            <directory>./tests/Filament</directory>
+        </testsuite>
     </testsuites>
     <php>
         <env name="APP_ENV" value="testing"/>

--- a/tests/Filament/Admin/ListEggsTest.php
+++ b/tests/Filament/Admin/ListEggsTest.php
@@ -4,8 +4,15 @@ use App\Enums\RolePermissionModels;
 use App\Filament\Admin\Resources\Eggs\Pages\ListEggs;
 use App\Models\Egg;
 use App\Models\Role;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
 
 use function Pest\Livewire\livewire;
+
+// These tables live on the admin panel; without this the default 'app' panel is
+// used and the resources' action urls fail to resolve.
+beforeEach(fn () => Filament::setCurrentPanel(Filament::getPanel('admin')));
+afterEach(fn () => Filament::setCurrentPanel(null));
 
 it('root admin can see all eggs', function () {
     $eggs = Egg::all();
@@ -22,8 +29,7 @@ it('root admin can see all eggs', function () {
 it('non root admin cannot see any eggs', function () {
     $role = Role::factory()->create(['name' => 'Node Viewer', 'guard_name' => 'web']);
     // Node Permission is on purpose, we check the wrong permissions.
-    $permission = Permission::factory()->create(['name' => RolePermissionModels::Node->viewAny(), 'guard_name' => 'web']);
-    $role->permissions()->attach($permission);
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Node->viewAny(), 'web'));
     [$user] = generateTestAccount([]);
 
     $this->actingAs($user);
@@ -33,8 +39,7 @@ it('non root admin cannot see any eggs', function () {
 
 it('non root admin with permissions can see eggs', function () {
     $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
-    $permission = Permission::factory()->create(['name' => RolePermissionModels::Egg->viewAny(), 'guard_name' => 'web']);
-    $role->permissions()->attach($permission);
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
 
     $eggs = Egg::all();
     [$user] = generateTestAccount([]);

--- a/tests/Filament/Admin/ListNodesTest.php
+++ b/tests/Filament/Admin/ListNodesTest.php
@@ -6,8 +6,16 @@ use App\Models\Node;
 use App\Models\Role;
 use App\Models\Server;
 use Filament\Actions\CreateAction;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
 
 use function Pest\Livewire\livewire;
+
+// These tables live on the admin panel; without this the default 'app' panel is
+// used and the resources' action urls fail to resolve.
+beforeEach(fn () => Filament::setCurrentPanel(Filament::getPanel('admin')));
+afterEach(fn () => Filament::setCurrentPanel(null));
 
 it('root admin can see all nodes', function () {
     [$admin] = generateTestAccount([]);
@@ -24,8 +32,7 @@ it('root admin can see all nodes', function () {
 it('non root admin cannot see any nodes', function () {
     $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
     // Egg Permission is on purpose, we check the wrong permissions.
-    $permission = Permission::factory()->create(['name' => RolePermissionModels::Egg->viewAny(), 'guard_name' => 'web']);
-    $role->permissions()->attach($permission);
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
     [$user] = generateTestAccount();
 
     $this->actingAs($user);
@@ -35,8 +42,7 @@ it('non root admin cannot see any nodes', function () {
 
 it('non root admin with permissions can see nodes', function () {
     $role = Role::factory()->create(['name' => 'Node Viewer', 'guard_name' => 'web']);
-    $permission = Permission::factory()->create(['name' => RolePermissionModels::Node->viewAny(), 'guard_name' => 'web']);
-    $role->permissions()->attach($permission);
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Node->viewAny(), 'web'));
 
     [$user] = generateTestAccount();
     $nodes = Node::all();
@@ -61,5 +67,5 @@ it('displays the create button in the table instead of the header when 0 nodes',
     livewire(ListNodes::class)
         ->assertSuccessful()
         ->assertHeaderMissing(CreateAction::class)
-        ->assertActionExists(CreateAction::class);
+        ->assertActionExists(TestAction::make('create')->table());
 });


### PR DESCRIPTION
`tests/Filament` wasn't in any phpunit testsuite and no CI job ran it, so those tests have never actually executed. They'd rotted in the meantime: `ListNodesTest` and `ListEggsTest` referenced an undefined `Permission` class, called a factory Spatie's model doesn't have, resolved action urls against the default `app` panel instead of `admin`, and asserted a toolbar action as if it were a record action.

Fixed the seven failures, added a `Filament` testsuite and ran it from the sqlite job. Nothing in them is database specific so there's no reason to repeat them across the mysql, mariadb and postgres matrices.