### PR TITLE
Throw when a transfer target node isn't viable

### DIFF
--- a/app/Exceptions/Http/Server/NodeNotViableException.php
+++ b/app/Exceptions/Http/Server/NodeNotViableException.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Exceptions\Http\Server;
+
+use App\Models\Node;
+use Symfony\Component\HttpKernel\Exception\NotAcceptableHttpException;
+use Throwable;
+
+/**
+ * Node was not viable
+ *
+ * Thrown when a node does not have enough free resources to take on the server
+ * being assigned to it.
+ */
+class NodeNotViableException extends NotAcceptableHttpException
+{
+    public function __construct(Node $node, ?Throwable $previous = null)
+    {
+        parent::__construct(trans('exceptions.node.not_viable', ['node' => $node->name]), $previous);
+    }
+}

--- a/app/Http/Controllers/Api/Application/Servers/ServerManagementController.php
+++ b/app/Http/Controllers/Api/Application/Servers/ServerManagementController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers\Api\Application\Servers;
 
 use App\Enums\SuspendAction;
 use App\Exceptions\DisplayException;
+use App\Exceptions\Http\Server\NodeNotViableException;
 use App\Exceptions\Model\DataValidationException;
 use App\Http\Controllers\Api\Application\ApplicationApiController;
 use App\Http\Requests\Api\Application\Servers\ServerWriteRequest;
@@ -13,6 +14,7 @@ use App\Services\Servers\ReinstallServerService;
 use App\Services\Servers\SuspensionService;
 use App\Services\Servers\TransferServerService;
 use Dedoc\Scramble\Attributes\Group;
+use Dedoc\Scramble\Attributes\Response as ResponseDoc;
 use Illuminate\Http\Client\ConnectionException;
 use Illuminate\Http\Response;
 use Illuminate\Support\Arr;
@@ -80,7 +82,10 @@ class ServerManagementController extends ApplicationApiController
      * Start transfer
      *
      * Starts a transfer of a server to a new node.
+     *
+     * @throws NodeNotViableException
      */
+    #[ResponseDoc(status: 406, description: 'Node was not viable')]
     public function startTransfer(ServerWriteRequest $request, Server $server): Response
     {
         $validatedData = $request->validate([
@@ -90,21 +95,14 @@ class ServerManagementController extends ApplicationApiController
             'allocation_additional.*' => 'integer|exists:allocations,id',
         ]);
 
-        if ($this->transferServerService->handle($server, Arr::get($validatedData, 'node_id'), Arr::get($validatedData, 'allocation_id'), Arr::get($validatedData, 'allocation_additional', []))) {
-            /**
-             * Transfer started
-             *
-             * @status 204
-             */
-            return $this->returnNoContent();
-        }
+        $this->transferServerService->handle($server, Arr::get($validatedData, 'node_id'), Arr::get($validatedData, 'allocation_id'), Arr::get($validatedData, 'allocation_additional', []));
 
         /**
-         * Node was not viable
+         * Transfer started
          *
-         * @status 406
+         * @status 204
          */
-        return $this->returnNotAcceptable();
+        return $this->returnNoContent();
     }
 
     /**

--- a/app/Services/Servers/TransferServerService.php
+++ b/app/Services/Servers/TransferServerService.php
@@ -3,6 +3,7 @@
 namespace App\Services\Servers;
 
 use App\Enums\NodeJwtScope;
+use App\Exceptions\Http\Server\NodeNotViableException;
 use App\Extensions\BackupAdapter\BackupAdapterService;
 use App\Extensions\BackupAdapter\Schemas\WingsBackupSchema;
 use App\Models\Allocation;
@@ -57,9 +58,10 @@ class TransferServerService
      * @param  int[]  $additional_allocations
      * @param  string[]  $backup_uuids
      *
+     * @throws NodeNotViableException
      * @throws Throwable
      */
-    public function handle(Server $server, int $node_id, ?int $allocation_id = null, ?array $additional_allocations = [], array $backup_uuids = []): bool
+    public function handle(Server $server, int $node_id, ?int $allocation_id = null, ?array $additional_allocations = [], array $backup_uuids = []): void
     {
         $additional_allocations = array_map(intval(...), $additional_allocations);
 
@@ -74,7 +76,7 @@ class TransferServerService
             ->first();
 
         if (!$node->isViable($server->memory, $server->disk, $server->cpu)) {
-            return false;
+            throw new NodeNotViableException($node);
         }
 
         $server->validateTransferState();
@@ -112,8 +114,6 @@ class TransferServerService
 
         // Notify the source node of the pending outgoing transfer.
         $this->notify($transfer, $token, $backup_uuids);
-
-        return true;
     }
 
     /**

--- a/lang/en/exceptions.php
+++ b/lang/en/exceptions.php
@@ -5,6 +5,7 @@ return [
     'node' => [
         'servers_attached' => 'A node must have no servers linked to it in order to be deleted.',
         'error_connecting' => 'Error connecting to :node',
+        'not_viable' => 'The node :node does not have enough free resources to accept this server.',
         'daemon_off_config_updated' => 'The daemon configuration <strong>has been updated</strong>, however there was an error encountered while attempting to automatically update the configuration file on the Daemon. You will need to manually update the configuration file (config.yml) for the daemon to apply these changes.',
     ],
     'allocations' => [

--- a/tests/Integration/Services/Servers/TransferServerServiceTest.php
+++ b/tests/Integration/Services/Servers/TransferServerServiceTest.php
@@ -1,0 +1,41 @@
+<?php
+
+namespace App\Tests\Integration\Services\Servers;
+
+use App\Exceptions\Http\Server\NodeNotViableException;
+use App\Models\Node;
+use App\Models\ServerTransfer;
+use App\Services\Servers\TransferServerService;
+use App\Tests\Integration\IntegrationTestCase;
+
+class TransferServerServiceTest extends IntegrationTestCase
+{
+    /**
+     * A node without the resources to take the server must abort the transfer loudly.
+     * It used to return false, which callers silently treated as success.
+     */
+    public function test_transfer_to_a_node_without_capacity_throws(): void
+    {
+        $server = $this->createServerModel(['memory' => 512]);
+
+        /** @var Node $target */
+        $target = Node::factory()->create([
+            'memory' => 128,
+            'memory_overallocate' => 0,
+        ]);
+
+        $this->expectException(NodeNotViableException::class);
+
+        try {
+            $this->getService()->handle($server, $target->id);
+        } finally {
+            $this->assertSame(0, ServerTransfer::query()->count());
+            $this->assertSame($server->node_id, $server->refresh()->node_id);
+        }
+    }
+
+    private function getService(): TransferServerService
+    {
+        return $this->app->make(TransferServerService::class);
+    }
+}


### PR DESCRIPTION
`TransferServerService::handle()` returned `false` when the target node didn't have the resources, but threw for a state conflict on the next line down. The admin transfer action wraps the call in a try/catch and treats the happy path as unconditional, so the `false` slipped through and it went on to delete every backup not selected for transfer and report "transfer started". Backups aren't soft deleted and wings cleans up the files behind it, so picking an undersized node loses them with no transfer.

Throws `NodeNotViableException` now so callers can't ignore it. The admin action needs no change, its existing catch fires the failure notification before the deletion loop. The API branched on the bool to return a 406 and keeps that status through the exception, with a `Response` attribute holding onto the description in the generated spec.