### PR TITLE
Stub the Vite manifest in tests so CI does not need a frontend build

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -36,6 +36,10 @@ abstract class TestCase extends BaseTestCase
         config()->set('app.debug', false);
         config()->set('panel.auth.2fa_required', 0);
 
+        // CI runs the test jobs without building the frontend, so rendered views
+        // must not require a Vite manifest.
+        $this->withoutVite();
+
         $this->setKnownUuidFactory();
 
         $this->app->make(PermissionRegistrar::class)->forgetCachedPermissions();


### PR DESCRIPTION
The file upload manager tests from #2540 render real server pages, which hit the `@vite` directive. CI test jobs never build the frontend, so every SQLite/MySQL/Postgres test job fails with "Vite manifest not found". Calling `withoutVite()` in the base TestCase stubs the directive for all tests.