### PR TITLE
Fix schedules dying for 24 hours after a stuck schedule:run

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -39,7 +39,7 @@ class Kernel extends ConsoleKernel
         }
 
         // Execute scheduled commands for servers every minute, as if there was a normal cron running.
-        $schedule->command(ProcessRunnableCommand::class)->everyMinute()->withoutOverlapping();
+        $schedule->command(ProcessRunnableCommand::class)->everyMinute()->withoutOverlapping(10);
 
         $schedule->command(CleanServiceBackupFilesCommand::class)->daily();
         $schedule->command(PruneImagesCommand::class)->daily();

--- a/app/Repositories/Daemon/DaemonServerRepository.php
+++ b/app/Repositories/Daemon/DaemonServerRepository.php
@@ -17,10 +17,10 @@ class DaemonServerRepository extends DaemonRepository
      *
      * @return array<string, mixed>
      */
-    public function getDetails(): array
+    public function getDetails(int $timeout = 1): array
     {
         try {
-            return $this->getHttpClient()->connectTimeout(1)->timeout(1)->get("/api/servers/{$this->server->uuid}")->throw()->json();
+            return $this->getHttpClient()->connectTimeout($timeout)->timeout($timeout)->get("/api/servers/{$this->server->uuid}")->throw()->json();
         } catch (RequestException $exception) {
             $cfId = $exception->response->header('Cf-Ray');
             $cfCache = $exception->response->header('Cf-Cache-Status');

--- a/app/Services/Schedules/ProcessScheduleService.php
+++ b/app/Services/Schedules/ProcessScheduleService.php
@@ -11,6 +11,7 @@ use App\Repositories\Daemon\DaemonServerRepository;
 use Exception;
 use Illuminate\Contracts\Bus\Dispatcher;
 use Illuminate\Database\ConnectionInterface;
+use Illuminate\Support\Facades\Log;
 
 class ProcessScheduleService
 {
@@ -39,15 +40,17 @@ class ProcessScheduleService
             // Check that the server is currently in a starting or running state before executing
             // this schedule if this option has been set.
             try {
-                $state = ContainerStatus::tryFrom(fluent($this->serverRepository->setServer($schedule->server)->getDetails())->get('state')) ?? ContainerStatus::Offline;
+                $state = ContainerStatus::tryFrom(fluent($this->serverRepository->setServer($schedule->server)->getDetails(timeout: 5))->get('state')) ?? ContainerStatus::Offline;
 
                 // If the server is stopping or offline just do nothing with this task.
                 if ($state->isOffline()) {
+                    Log::warning("Skipping schedule '{$schedule->name}' ({$schedule->id}) for server {$schedule->server->uuid}: server state is {$state->value}");
                     $job->failed();
 
                     return;
                 }
-            } catch (Exception) {
+            } catch (Exception $exception) {
+                Log::warning("Skipping schedule '{$schedule->name}' ({$schedule->id}) for server {$schedule->server->uuid}: {$exception->getMessage()}");
                 $job->failed();
 
                 return;


### PR DESCRIPTION
Fixes #2543

A single hung `schedule:run` holds the `withoutOverlapping()` mutex for Laravel's default 24 hours, so every later per-minute run silently skips `p:schedule:process` until the mutex expires. That's the "overlapping jobs" warning flood in the issue, and why schedules appear dead until something clears the state. On top of that, the `only_when_online` check is a 1 second call to Wings that treats any failure as "offline" and skips the run with no log output, after `next_run_at` was already advanced.

### Changes
- Cap the schedule mutex at 10 minutes, so a stuck run self-heals instead of killing schedules for a day
- Give the `only_when_online` check a 5 second timeout (`getDetails()` keeps its 1 second default for UI polling)
- Log a warning whenever a schedule is skipped, so these are never silent again

### Verified
Reproduced on the stock Docker image: wedge one `schedule:run`, kill it, and the orphaned mutex (~24h TTL on file cache) silently suppresses schedule processing indefinitely. With this branch built into the image, the same wedge self-heals in exactly 10 minutes, and a schedule pointing at an unreachable node logs `Skipping schedule 'Nightly Restart' (1) for server <uuid>: server state is missing` instead of nothing.
