### PR TITLE
Hide activity of role-based admins from server activity logs

### DIFF
--- a/app/Filament/Server/Resources/Activities/ActivityResource.php
+++ b/app/Filament/Server/Resources/Activities/ActivityResource.php
@@ -7,7 +7,6 @@ use App\Filament\Admin\Resources\Users\Pages\EditUser;
 use App\Filament\Components\Tables\Columns\DateTimeColumn;
 use App\Filament\Server\Resources\Activities\Pages\ListActivities;
 use App\Models\ActivityLog;
-use App\Models\Role;
 use App\Models\Server;
 use App\Models\User;
 use App\Traits\Filament\CanCustomizePages;
@@ -28,7 +27,6 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 
@@ -152,23 +150,7 @@ class ActivityResource extends Resource
 
         return ActivityLog::whereHas('subjects', fn (Builder $query) => $query->where('subject_id', $server->id)->where('subject_type', $server->getMorphClass()))
             ->whereNotIn('activity_logs.event', ActivityLog::DISABLED_EVENTS)
-            ->when(config('activity.hide_admin_activity'), function (Builder $builder) use ($server) {
-                // We could do this with a query and a lot of joins, but that gets pretty
-                // painful so for now we'll execute a simpler query.
-                $subusers = $server->subusers()->pluck('user_id')->merge([$server->owner_id]);
-                $rootAdmins = Role::getRootAdmin()->users()->pluck('id');
-
-                $builder->select('activity_logs.*')
-                    ->leftJoin('users', function (JoinClause $join) {
-                        $join->on('users.id', 'activity_logs.actor_id')
-                            ->where('activity_logs.actor_type', (new User())->getMorphClass());
-                    })
-                    ->where(function (Builder $builder) use ($subusers, $rootAdmins) {
-                        $builder->whereNull('users.id')
-                            ->orWhereNotIn('users.id', $rootAdmins)
-                            ->orWhereIn('users.id', $subusers);
-                    });
-            });
+            ->when(config('activity.hide_admin_activity'), fn (Builder $builder) => $builder->hideAdminActivity($server));
     }
 
     /** @return array<string, PageRegistration> */

--- a/app/Http/Controllers/Api/Client/Servers/ActivityLogController.php
+++ b/app/Http/Controllers/Api/Client/Servers/ActivityLogController.php
@@ -7,12 +7,9 @@ use App\Enums\SubuserPermission;
 use App\Http\Controllers\Api\Client\ClientApiController;
 use App\Http\Requests\Api\Client\ClientApiRequest;
 use App\Models\ActivityLog;
-use App\Models\Role;
 use App\Models\Server;
-use App\Models\User;
 use Dedoc\Scramble\Attributes\Group;
 use Illuminate\Database\Eloquent\Builder;
-use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Facades\Gate;
 use Spatie\QueryBuilder\AllowedFilter;
 use Spatie\QueryBuilder\QueryBuilder;
@@ -31,28 +28,14 @@ class ActivityLogController extends ClientApiController
     {
         Gate::authorize(SubuserPermission::ActivityRead, $server);
 
-        $activity = QueryBuilder::for($server->activity())
+        $query = ActivityLog::whereHas('subjects', fn (Builder $query) => $query->where('subject_id', $server->id)->where('subject_type', $server->getMorphClass()))
+            ->whereNotIn('activity_logs.event', ActivityLog::DISABLED_EVENTS)
+            ->when(config('activity.hide_admin_activity'), fn (Builder $builder) => $builder->hideAdminActivity($server));
+
+        $activity = QueryBuilder::for($query)
             ->allowedSorts(['timestamp'])
             ->allowedFilters([AllowedFilter::partial('event')])
             ->with('actor')
-            ->whereNotIn('activity_logs.event', ActivityLog::DISABLED_EVENTS)
-            ->when(config('activity.hide_admin_activity'), function (Builder $builder) use ($server) {
-                // We could do this with a query and a lot of joins, but that gets pretty
-                // painful so for now we'll execute a simpler query.
-                $subusers = $server->subusers()->pluck('user_id')->merge([$server->owner_id]);
-                $rootAdmins = Role::getRootAdmin()->users()->pluck('id');
-
-                $builder->select('activity_logs.*')
-                    ->leftJoin('users', function (JoinClause $join) {
-                        $join->on('users.id', 'activity_logs.actor_id')
-                            ->where('activity_logs.actor_type', (new User())->getMorphClass());
-                    })
-                    ->where(function (Builder $builder) use ($subusers, $rootAdmins) {
-                        $builder->whereNull('users.id')
-                            ->orWhereNotIn('users.id', $rootAdmins)
-                            ->orWhereIn('users.id', $subusers);
-                    });
-            })
             ->paginate(min($request->query('per_page', '25'), 100))
             ->appends($request->query());
 

--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -14,6 +14,7 @@ use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
+use Illuminate\Database\Query\JoinClause;
 use Illuminate\Support\Arr;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Collection;
@@ -39,6 +40,7 @@ use LogicException;
  *
  * @method static Builder<static>|ActivityLog forActor(\Illuminate\Database\Eloquent\Model $actor)
  * @method static Builder<static>|ActivityLog forEvent(string $action)
+ * @method static Builder<static>|ActivityLog hideAdminActivity(\App\Models\Server $server)
  * @method static Builder<static>|ActivityLog newModelQuery()
  * @method static Builder<static>|ActivityLog newQuery()
  * @method static Builder<static>|ActivityLog query()
@@ -119,6 +121,26 @@ class ActivityLog extends Model implements HasIcon, HasLabel
     public function scopeForActor(Builder $builder, Model $actor): Builder
     {
         return $builder->whereMorphedTo('actor', $actor);
+    }
+
+    /**
+     * Hides entries whose actor holds any role (an admin) but is not the owner
+     * or a subuser of the given server.
+     */
+    public function scopeHideAdminActivity(Builder $builder, Server $server): Builder
+    {
+        $members = $server->subusers()->pluck('user_id')->merge([$server->owner_id]);
+
+        return $builder->select('activity_logs.*')
+            ->leftJoin('users', function (JoinClause $join) {
+                $join->on('users.id', 'activity_logs.actor_id')
+                    ->where('activity_logs.actor_type', (new User())->getMorphClass());
+            })
+            ->where(function (Builder $builder) use ($members) {
+                $builder->whereNull('users.id')
+                    ->orWhereNotIn('users.id', User::whereHas('roles')->select('id'))
+                    ->orWhereIn('users.id', $members);
+            });
     }
 
     public function prunable(): Builder

--- a/tests/Filament/Server/ListActivitiesTest.php
+++ b/tests/Filament/Server/ListActivitiesTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Filament\Server\Resources\Activities\Pages\ListActivities;
+use App\Models\ActivityLog;
+use App\Models\Role;
+use App\Models\Server;
+use App\Models\User;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(fn () => Filament::setCurrentPanel('server'));
+
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+function createServerActivity(Server $server, ?User $actor): ActivityLog
+{
+    $log = new ActivityLog([
+        'event' => 'server:file.read',
+        'ip' => '127.0.0.1',
+        'properties' => [],
+    ]);
+
+    if ($actor) {
+        $log->actor()->associate($actor);
+    }
+
+    $log->save();
+
+    $log->subjects()->create([
+        'subject_id' => $server->id,
+        'subject_type' => $server->getMorphClass(),
+    ]);
+
+    return $log;
+}
+
+it('hides activity from admins with a custom role when hide admin activity is enabled', function () {
+    config()->set('activity.hide_admin_activity', true);
+
+    [$user, $server] = generateTestAccount();
+
+    /** @var User $admin */
+    $admin = User::factory()->create();
+    /** @var Role $role */
+    $role = Role::factory()->create(['name' => 'Support', 'guard_name' => 'web']);
+    $role->givePermissionTo(Permission::findOrCreate('view server', 'web'));
+    $admin->syncRoles($role);
+
+    $adminLog = createServerActivity($server, $admin);
+    $ownerLog = createServerActivity($server, $user);
+
+    $this->actingAs($user);
+    Filament::setTenant($server);
+
+    livewire(ListActivities::class)
+        ->assertCanSeeTableRecords([$ownerLog])
+        ->assertCanNotSeeTableRecords([$adminLog]);
+});
+
+it('shows admin activity when hide admin activity is disabled', function () {
+    config()->set('activity.hide_admin_activity', false);
+
+    [$user, $server] = generateTestAccount();
+
+    /** @var User $admin */
+    $admin = User::factory()->create();
+    $admin->syncRoles(Role::getRootAdmin());
+
+    $adminLog = createServerActivity($server, $admin);
+
+    $this->actingAs($user);
+    Filament::setTenant($server);
+
+    livewire(ListActivities::class)
+        ->assertCanSeeTableRecords([$adminLog]);
+});

--- a/tests/Integration/Api/Client/Server/ActivityLogControllerTest.php
+++ b/tests/Integration/Api/Client/Server/ActivityLogControllerTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace App\Tests\Integration\Api\Client\Server;
+
+use App\Enums\SubuserPermission;
+use App\Models\ActivityLog;
+use App\Models\Role;
+use App\Models\Server;
+use App\Models\User;
+use App\Tests\Integration\Api\Client\ClientApiIntegrationTestCase;
+use Spatie\Permission\Models\Permission;
+
+class ActivityLogControllerTest extends ClientApiIntegrationTestCase
+{
+    /**
+     * Test that activity from an admin with a custom role is hidden from the server's
+     * activity log when the hide admin activity option is enabled.
+     */
+    public function test_custom_role_admin_activity_is_hidden_when_enabled(): void
+    {
+        config()->set('activity.hide_admin_activity', true);
+
+        [$user, $server] = $this->generateTestAccount();
+
+        /** @var User $admin */
+        $admin = User::factory()->create();
+        /** @var Role $role */
+        $role = Role::factory()->create(['name' => 'Support', 'guard_name' => 'web']);
+        $role->givePermissionTo(Permission::findOrCreate('view server', 'web'));
+        $admin->syncRoles($role);
+
+        $log = $this->createActivity($server, $admin);
+
+        $response = $this->actingAs($user)->getJson($this->link($server, '/activity'));
+
+        $response->assertOk();
+        $response->assertJsonCount(0, 'data');
+        $response->assertJsonMissing(['id' => sha1((string) $log->id)]);
+    }
+
+    /**
+     * Test that activity from a root admin is hidden from the server's activity
+     * log when the hide admin activity option is enabled.
+     */
+    public function test_root_admin_activity_is_hidden_when_enabled(): void
+    {
+        config()->set('activity.hide_admin_activity', true);
+
+        [$user, $server] = $this->generateTestAccount();
+
+        /** @var User $admin */
+        $admin = User::factory()->create();
+        $admin->syncRoles(Role::getRootAdmin());
+
+        $this->createActivity($server, $admin);
+
+        $this->actingAs($user)
+            ->getJson($this->link($server, '/activity'))
+            ->assertOk()
+            ->assertJsonCount(0, 'data');
+    }
+
+    /**
+     * Test that activity from the server owner, a subuser (even one holding a role),
+     * and the system is still shown when the hide admin activity option is enabled.
+     */
+    public function test_member_and_system_activity_is_shown_when_enabled(): void
+    {
+        config()->set('activity.hide_admin_activity', true);
+
+        [$subuser, $server] = $this->generateTestAccount([SubuserPermission::ActivityRead]);
+        /** @var Role $role */
+        $role = Role::factory()->create(['name' => 'Support', 'guard_name' => 'web']);
+        $role->givePermissionTo(Permission::findOrCreate('view server', 'web'));
+        $subuser->syncRoles($role);
+
+        $this->createActivity($server, $server->user);
+        $this->createActivity($server, $subuser);
+        $this->createActivity($server, null);
+
+        $this->actingAs($server->user)
+            ->getJson($this->link($server, '/activity'))
+            ->assertOk()
+            ->assertJsonCount(3, 'data');
+    }
+
+    /**
+     * Test that admin activity is shown when the hide admin activity option is disabled.
+     */
+    public function test_admin_activity_is_shown_when_disabled(): void
+    {
+        config()->set('activity.hide_admin_activity', false);
+
+        [$user, $server] = $this->generateTestAccount();
+
+        /** @var User $admin */
+        $admin = User::factory()->create();
+        $admin->syncRoles(Role::getRootAdmin());
+
+        $this->createActivity($server, $admin);
+
+        $this->actingAs($user)
+            ->getJson($this->link($server, '/activity'))
+            ->assertOk()
+            ->assertJsonCount(1, 'data');
+    }
+
+    private function createActivity(Server $server, ?User $actor): ActivityLog
+    {
+        $log = new ActivityLog([
+            'event' => 'server:file.read',
+            'ip' => '127.0.0.1',
+            'properties' => [],
+        ]);
+
+        if ($actor) {
+            $log->actor()->associate($actor);
+        }
+
+        $log->save();
+
+        $log->subjects()->create([
+            'subject_id' => $server->id,
+            'subject_type' => $server->getMorphClass(),
+        ]);
+
+        return $log;
+    }
+}


### PR DESCRIPTION
Fixes #2527

The `hide_admin_activity` filter only excluded members of the **Root Admin** role, so admins granted access through custom roles still appeared in the activity logs of servers they aren't a member of.

### Changes
- Moved the query duplicated between `ActivityResource` and the client `ActivityLogController` into a shared `ActivityLog::hideAdminActivity()` scope
- Widened the hidden set from Root Admin members to any actor holding a role who isn't the server owner or a subuser
- Added tests covering both the server activity page and the client API endpoint