### PR TITLE
Make SoftwareVersionService the single source of truth for version reads

### DIFF
--- a/app/Checks/PanelVersionCheck.php
+++ b/app/Checks/PanelVersionCheck.php
@@ -21,8 +21,15 @@ class PanelVersionCheck extends Check
                 'isLatest' => $isLatest,
                 'currentVersion' => $currentVersion,
                 'latestVersion' => $latestVersion,
-            ])
-            ->shortSummary($isLatest ? trans('admin/health.results.panelversion.up_to_date') : trans('admin/health.results.panelversion.outdated'));
+            ]);
+
+        if (is_null($latestVersion)) {
+            return $result
+                ->shortSummary(trans('admin/health.results.panelversion.unknown'))
+                ->warning(trans('admin/health.results.panelversion.unavailable'));
+        }
+
+        $result->shortSummary($isLatest ? trans('admin/health.results.panelversion.up_to_date') : trans('admin/health.results.panelversion.outdated'));
 
         return $isLatest
             ? $result->ok(trans('admin/health.results.panelversion.ok'))

--- a/app/Console/Commands/Plugin/MakePluginCommand.php
+++ b/app/Console/Commands/Plugin/MakePluginCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\Plugin;
 
 use App\Enums\PluginCategory;
 use App\Enums\PluginStatus;
+use App\Services\Helpers\SoftwareVersionService;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -27,7 +28,7 @@ class MakePluginCommand extends Command
         parent::__construct();
     }
 
-    public function handle(): void
+    public function handle(SoftwareVersionService $versionService): void
     {
         $name = $this->option('name') ?? $this->ask('Name');
         $name = preg_replace('/[^A-Za-z0-9 ]/', '', Str::ascii($name));
@@ -84,7 +85,7 @@ class MakePluginCommand extends Command
 
         $panelVersion = $this->option('panelVersion');
         if (!$panelVersion) {
-            $panelVersion = $this->ask('Required panel version (leave empty for no constraint)', config('app.version') === 'canary' ? null : config('app.version'));
+            $panelVersion = $this->ask('Required panel version (leave empty for no constraint)', $versionService->currentComparableVersion());
 
             if ($panelVersion && $this->confirm("Should the version constraint be minimal instead of strict? ($panelVersion or higher instead of only $panelVersion)")) {
                 $panelVersion = "^$panelVersion";

--- a/app/Filament/Admin/Resources/Nodes/NodeResource.php
+++ b/app/Filament/Admin/Resources/Nodes/NodeResource.php
@@ -139,7 +139,7 @@ class NodeResource extends Resource
                         ->schema([
                             TextEntry::make('wings_version')
                                 ->label(trans('admin/node.wings_version'))
-                                ->state(fn (Node $node, SoftwareVersionService $versionService) => ($node->systemInformation()['version'] ?? trans('admin/node.unknown')) . ' ' . trans('admin/node.latest', ['version' => $versionService->latestWingsVersion()])),
+                                ->state(fn (Node $node, SoftwareVersionService $versionService) => ($node->systemInformation()['version'] ?? trans('admin/node.unknown')) . ' ' . trans('admin/node.latest', ['version' => $versionService->latestWingsVersion() ?? trans('admin/node.unknown')])),
                             TextEntry::make('cpu_threads')
                                 ->label(trans('admin/node.cpu_threads'))
                                 ->state(fn (Node $node) => $node->systemInformation()['cpu_count'] ?? 0),

--- a/app/Filament/Admin/Widgets/CanaryWidget.php
+++ b/app/Filament/Admin/Widgets/CanaryWidget.php
@@ -3,11 +3,13 @@
 namespace App\Filament\Admin\Widgets;
 
 use App\Enums\TablerIcon;
+use App\Services\Helpers\SoftwareVersionService;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Infolists\Components\TextEntry;
 use Filament\Schemas\Components\Section;
 use Filament\Schemas\Schema;
+use Illuminate\Support\Facades\App;
 
 class CanaryWidget extends FormWidget
 {
@@ -15,7 +17,7 @@ class CanaryWidget extends FormWidget
 
     public static function canView(): bool
     {
-        return config('app.version') === 'canary';
+        return App::call(fn (SoftwareVersionService $service) => $service->currentComparableVersion()) === null;
     }
 
     /**

--- a/app/Filament/Admin/Widgets/UpdateWidget.php
+++ b/app/Filament/Admin/Widgets/UpdateWidget.php
@@ -26,7 +26,24 @@ class UpdateWidget extends FormWidget
      */
     public function form(Schema $schema): Schema
     {
+        $latestVersion = $this->softwareVersionService->latestPanelVersion();
+
+        if ($latestVersion === null && $this->softwareVersionService->currentComparableVersion() !== null) {
+            return $schema
+                ->components([
+                    Section::make(trans('admin/dashboard.sections.intro-version-unavailable.heading'))
+                        ->icon(TablerIcon::CloudOff)
+                        ->iconColor('gray')
+                        ->schema([
+                            TextEntry::make('info')
+                                ->hiddenLabel()
+                                ->state(trans('admin/dashboard.sections.intro-version-unavailable.content', ['version' => $this->softwareVersionService->currentPanelVersion()])),
+                        ]),
+                ]);
+        }
+
         $isLatest = $this->softwareVersionService->isLatestPanel();
+        $isContainer = file_exists('/.dockerenv');
 
         return $schema
             ->components([
@@ -45,7 +62,7 @@ class UpdateWidget extends FormWidget
                     ->schema([
                         TextEntry::make('info')
                             ->hiddenLabel()
-                            ->state(trans('admin/dashboard.sections.intro-update-available.content', ['latestVersion' => $this->softwareVersionService->latestPanelVersion()])),
+                            ->state(trans('admin/dashboard.sections.intro-update-available.' . ($isContainer ? 'content_container' : 'content'), ['latestVersion' => $latestVersion])),
                         Section::make(trans('admin/dashboard.sections.intro-update-available.button_changelog'))
                             ->icon(TablerIcon::Script)
                             ->collapsible()

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -7,10 +7,12 @@ use App\Enums\PluginCategory;
 use App\Enums\PluginStatus;
 use App\Exceptions\PluginIdMismatchException;
 use App\Facades\Plugins;
+use App\Services\Helpers\SoftwareVersionService;
 use Exception;
 use Filament\Schemas\Components\Component;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Http;
 use Illuminate\Support\Str;
@@ -230,9 +232,9 @@ class Plugin extends Model implements HasPluginSettings
 
     public function isCompatible(): bool
     {
-        $currentPanelVersion = config('app.version', 'canary');
+        $currentPanelVersion = App::call(fn (SoftwareVersionService $service) => $service->currentComparableVersion());
 
-        return !$this->panel_version || $currentPanelVersion === 'canary' || version_compare($currentPanelVersion, str($this->panel_version)->trim('^'), $this->isPanelVersionStrict() ? '=' : '>=');
+        return !$this->panel_version || $currentPanelVersion === null || version_compare($currentPanelVersion, str($this->panel_version)->trim('^'), $this->isPanelVersionStrict() ? '=' : '>=');
     }
 
     public function isPanelVersionStrict(): bool
@@ -281,9 +283,9 @@ class Plugin extends Model implements HasPluginSettings
 
     public function isUpdateAvailable(): bool
     {
-        $panelVersion = config('app.version', 'canary');
+        $panelVersion = App::call(fn (SoftwareVersionService $service) => $service->currentComparableVersion());
 
-        if ($panelVersion === 'canary') {
+        if ($panelVersion === null) {
             return false;
         }
 
@@ -303,9 +305,9 @@ class Plugin extends Model implements HasPluginSettings
 
     public function getDownloadUrlForUpdate(): ?string
     {
-        $panelVersion = config('app.version', 'canary');
+        $panelVersion = App::call(fn (SoftwareVersionService $service) => $service->currentComparableVersion());
 
-        if ($panelVersion === 'canary') {
+        if ($panelVersion === null) {
             return null;
         }
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -121,8 +121,10 @@ class AppServiceProvider extends ServiceProvider
 
         AboutCommand::add('Pelican', [
             'Panel Version' => $versionService->currentPanelVersion(),
-            'Latest Version' => $versionService->latestPanelVersion(),
-            'Up-to-Date' => $versionService->isLatestPanel() ? '<fg=green;options=bold>Yes</>' : '<fg=red;options=bold>No</>',
+            'Latest Version' => $versionService->latestPanelVersion() ?? 'Unknown',
+            'Up-to-Date' => is_null($versionService->latestPanelVersion())
+                ? '<fg=yellow;options=bold>Unknown</>'
+                : ($versionService->isLatestPanel() ? '<fg=green;options=bold>Yes</>' : '<fg=red;options=bold>No</>'),
         ]);
 
         AboutCommand::add('Environment', 'Installation Directory', base_path());

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -44,7 +44,7 @@ class PluginService
             try {
                 // Filter out plugins that are not compatible with the current panel version
                 if (!$plugin->isCompatible()) {
-                    $this->setStatus($plugin, PluginStatus::Incompatible, 'This Plugin is only compatible with Panel version ' . $plugin->panel_version . (!$plugin->isPanelVersionStrict() ? ' or newer' : '') . ' but you are using version ' . config('app.version') . '!');
+                    $this->setStatus($plugin, PluginStatus::Incompatible, 'This Plugin is only compatible with Panel version ' . $plugin->panel_version . (!$plugin->isPanelVersionStrict() ? ' or newer' : '') . ' but you are using version ' . $this->app->make(SoftwareVersionService::class)->currentPanelVersion() . '!');
 
                     continue;
                 } else {

--- a/app/Services/Helpers/SoftwareVersionService.php
+++ b/app/Services/Helpers/SoftwareVersionService.php
@@ -7,14 +7,14 @@ use Illuminate\Support\Facades\Http;
 
 class SoftwareVersionService
 {
-    public function latestPanelVersionChangelog(): string
+    public function latestPanelVersionChangelog(): ?string
     {
         $key = 'panel:latest_version_changelog';
         if (cache()->get($key) === 'error') {
             cache()->forget($key);
         }
 
-        return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
+        $changelog = cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
                 $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/panel/releases/latest')->throw()->json();
 
@@ -23,16 +23,18 @@ class SoftwareVersionService
                 return 'error';
             }
         });
+
+        return $changelog === 'error' ? null : $changelog;
     }
 
-    public function latestPanelVersion(): string
+    public function latestPanelVersion(): ?string
     {
         $key = 'panel:latest_version';
         if (cache()->get($key) === 'error') {
             cache()->forget($key);
         }
 
-        return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
+        $version = cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
                 $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/panel/releases/latest')->throw()->json();
 
@@ -41,16 +43,18 @@ class SoftwareVersionService
                 return 'error';
             }
         });
+
+        return $version === 'error' ? null : $version;
     }
 
-    public function latestWingsVersion(): string
+    public function latestWingsVersion(): ?string
     {
         $key = 'wings:latest_version';
         if (cache()->get($key) === 'error') {
             cache()->forget($key);
         }
 
-        return cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
+        $version = cache()->remember($key, now()->addMinutes(config('panel.cdn.cache_time', 60)), function () {
             try {
                 $response = Http::timeout(5)->connectTimeout(1)->get('https://api.github.com/repos/pelican/wings/releases/latest')->throw()->json();
 
@@ -59,29 +63,37 @@ class SoftwareVersionService
                 return 'error';
             }
         });
+
+        return $version === 'error' ? null : $version;
     }
 
     public function isLatestPanel(): bool
     {
-        if (config('app.version') === 'canary') {
-            return true;
-        }
+        $current = $this->currentComparableVersion();
+        $latest = $this->latestPanelVersion();
 
-        return version_compare(config('app.version'), $this->latestPanelVersion()) >= 0;
+        return $current === null || $latest === null || version_compare($current, $latest, '>=');
     }
 
     public function isLatestWings(string $version): bool
     {
-        if ($version === 'develop') {
-            return true;
-        }
+        $latest = $this->latestWingsVersion();
 
-        return version_compare($version, $this->latestWingsVersion()) >= 0;
+        return $version === 'develop' || $latest === null || version_compare($version, $latest, '>=');
     }
 
+    /**
+     * The version for display purposes, e.g. "1.2.3" or "canary (0a1b2c3)". Never use this for comparisons.
+     */
     public function currentPanelVersion(): string
     {
         return cache()->remember('panel:current_version', now()->addMinutes(5), function () {
+            $version = config('app.version');
+
+            if ($version !== 'canary') {
+                return $version;
+            }
+
             if (file_exists(base_path('.git/HEAD'))) {
                 $head = explode(' ', file_get_contents(base_path('.git/HEAD')));
 
@@ -94,7 +106,17 @@ class SoftwareVersionService
                 }
             }
 
-            return config('app.version');
+            return $version;
         });
+    }
+
+    /**
+     * The comparable semver of this installation, or null when running canary.
+     */
+    public function currentComparableVersion(): ?string
+    {
+        $version = config('app.version');
+
+        return $version === 'canary' ? null : $version;
     }
 }

--- a/lang/en/admin/dashboard.php
+++ b/lang/en/admin/dashboard.php
@@ -17,7 +17,12 @@ return [
         'intro-update-available' => [
             'heading' => 'Update available',
             'content' => ':latestVersion is now available! Read our documentation to update your Panel.',
+            'content_container' => ':latestVersion is now available! Pull the new image and recreate the container to update your Panel.',
             'button_changelog' => 'What\'s New?',
+        ],
+        'intro-version-unavailable' => [
+            'heading' => 'Version check unavailable',
+            'content' => 'You are currently using :version. The latest version could not be fetched from GitHub, so it is unknown whether an update is available.',
         ],
         'intro-no-update' => [
             'heading' => 'Your Panel is up to date',

--- a/lang/en/admin/health.php
+++ b/lang/en/admin/health.php
@@ -42,6 +42,8 @@ return [
             'failed' => 'Installed version is :currentVersion but latest is :latestVersion',
             'up_to_date' => 'Up to date',
             'outdated' => 'Outdated',
+            'unknown' => 'Unknown',
+            'unavailable' => 'The latest version could not be fetched from GitHub',
         ],
         'schedule' => [
             'label' => 'Schedule',

--- a/tests/Unit/Services/Helpers/SoftwareVersionServiceTest.php
+++ b/tests/Unit/Services/Helpers/SoftwareVersionServiceTest.php
@@ -1,0 +1,81 @@
+<?php
+
+namespace App\Tests\Unit\Services\Helpers;
+
+use App\Services\Helpers\SoftwareVersionService;
+use App\Tests\TestCase;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class SoftwareVersionServiceTest extends TestCase
+{
+    private SoftwareVersionService $service;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->service = new SoftwareVersionService();
+        cache()->flush();
+    }
+
+    #[DataProvider('isLatestPanelDataProvider')]
+    public function test_is_latest_panel(string $current, string $latest, bool $expected): void
+    {
+        config()->set('app.version', $current);
+        Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v' . $latest])]);
+
+        $this->assertSame($expected, $this->service->isLatestPanel());
+    }
+
+    public static function isLatestPanelDataProvider(): array
+    {
+        return [
+            'canary is always latest' => ['canary', '1.0.0', true],
+            'equal versions' => ['1.0.0', '1.0.0', true],
+            'newer than latest' => ['1.1.0', '1.0.0', true],
+            'older than latest' => ['0.9.0', '1.0.0', false],
+            'prerelease older than its stable' => ['1.0.0-rc1', '1.0.0', false],
+            'stable newer than a prerelease' => ['1.0.0', '1.0.0-rc1', true],
+        ];
+    }
+
+    public function test_latest_versions_are_null_when_fetch_fails(): void
+    {
+        Http::fake(['api.github.com/*' => Http::response(null, 500)]);
+
+        $this->assertNull($this->service->latestPanelVersion());
+        $this->assertNull($this->service->latestWingsVersion());
+        $this->assertNull($this->service->latestPanelVersionChangelog());
+    }
+
+    public function test_is_latest_panel_when_fetch_fails(): void
+    {
+        config()->set('app.version', '1.0.0');
+        Http::fake(['api.github.com/*' => Http::response(null, 500)]);
+
+        $this->assertTrue($this->service->isLatestPanel());
+    }
+
+    public function test_latest_panel_version_returns_trimmed_tag(): void
+    {
+        Http::fake(['api.github.com/*' => Http::response(['tag_name' => 'v1.2.3'])]);
+
+        $this->assertSame('1.2.3', $this->service->latestPanelVersion());
+    }
+
+    public function test_current_panel_version_prefers_stamped_version_over_git(): void
+    {
+        config()->set('app.version', '1.2.3');
+
+        $this->assertSame('1.2.3', $this->service->currentPanelVersion());
+        $this->assertSame('1.2.3', $this->service->currentComparableVersion());
+    }
+
+    public function test_current_comparable_version_is_null_on_canary(): void
+    {
+        config()->set('app.version', 'canary');
+
+        $this->assertNull($this->service->currentComparableVersion());
+    }
+}


### PR DESCRIPTION
Part of the 1.0 versioning work.

* A failed GitHub fetch previously cached the literal string `error`, and `version_compare('1.2.3', 'error')` reported the panel as up to date. The latest version methods now return `null` on failure, the dashboard shows a "Version check unavailable" section, the health check reports a warning, and `p:info` shows Unknown instead of a false green.
* `currentPanelVersion()` preferred `.git/HEAD` over the stamped config version, so a stamped release with a leftover `.git` directory displayed as canary. The stamped version now wins, and the git sha display only applies to actual canary installs.
* Version reads are split into two explicit concepts: `currentComparableVersion()` (a semver or null on canary, safe for `version_compare`) and `currentPanelVersion()` (display only). All raw `config('app.version')` reads in Plugin, PluginService, CanaryWidget, and p:plugin:make are routed through the service.
* Prerelease detection now falls out of plain semver ordering, so a `1.0.0-rc1` install correctly reports an update once `1.0.0` is released, covered by a new test matrix.
* When an update is available and the panel runs in a container, the dashboard now says to pull the new image instead of linking file update steps.
### Screenshots

<img width="1564" height="153" alt="version-check-unavailable" src="https://github.com/user-attachments/assets/b0076388-4d33-4497-82e1-4491e7720c0b" />
<img width="1568" height="248" alt="update-available" src="https://github.com/user-attachments/assets/9d8388e7-6914-42b3-b173-bbcdd0a79a20" />
<img width="1568" height="248" alt="update-available-container" src="https://github.com/user-attachments/assets/d1b3217c-6715-471a-b672-47bcaf8c506c" />
