### PR TITLE
Fail tagged builds when version stamping misses

### DIFF
--- a/.github/actions/stamp-version/action.yml
+++ b/.github/actions/stamp-version/action.yml
@@ -15,7 +15,7 @@ runs:
         VERSION: ${{ inputs.version }}
       run: |
         VERSION="${VERSION#v}"
-        if [ -z "$VERSION" ] || [[ "$VERSION" == refs/* ]] || [[ "$VERSION" == main ]]; then
+        if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.]+)?$ ]]; then
           echo "Invalid version '$VERSION', refusing to update config"
           exit 1
         fi

--- a/.github/actions/stamp-version/action.yml
+++ b/.github/actions/stamp-version/action.yml
@@ -1,0 +1,26 @@
+name: Stamp version
+description: Replace the canary version in config/app.php with the release version and fail if the replacement did not happen
+
+inputs:
+  version:
+    description: The version to stamp, with or without the leading v
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Stamp version in config/app.php
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+      run: |
+        VERSION="${VERSION#v}"
+        if [ -z "$VERSION" ] || [[ "$VERSION" == refs/* ]] || [[ "$VERSION" == main ]]; then
+          echo "Invalid version '$VERSION', refusing to update config"
+          exit 1
+        fi
+        sed -i "s|'version' => 'canary',|'version' => '$VERSION',|" config/app.php
+        if ! grep -qF "'version' => '$VERSION'," config/app.php; then
+          echo "Version stamp failed, config/app.php still does not contain '$VERSION'"
+          exit 1
+        fi

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -158,13 +158,10 @@ jobs:
           
       - name: Update version in config/app.php (tag)
         if: "(github.event_name == 'release' && github.event.action == 'published') || github.event_name == 'schedule'"
-        run: |
-          VERSION="${{ github.event_name == 'schedule' && steps.release_info.outputs.version_tag || steps.build_info.outputs.version_tag }}"
-          if [ -z "$VERSION" ] || [ "$VERSION" = "refs/heads/main" ]; then
-            echo "Invalid version tag, refusing to update config"
-            exit 1
-          fi
-          sed -i "s|'version' => 'canary',|'version' => '$VERSION',|" config/app.php
+        # Referenced from main instead of the working tree because scheduled runs check out a release tag that may not contain the action
+        uses: pelican/panel/.github/actions/stamp-version@main
+        with:
+          version: ${{ github.event_name == 'schedule' && steps.release_info.outputs.version_tag || steps.build_info.outputs.version_tag }}
               
       - name: Build and Push (tag)
         uses: docker/build-push-action@v7

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,11 @@ jobs:
       - name: Build
         run: yarn build
 
+      - name: Stamp version
+        uses: ./.github/actions/stamp-version
+        with:
+          version: ${{ github.ref_name }}
+
       - name: Create release branch and bump version
         env:
           REF: ${{ github.ref }}
@@ -48,7 +53,6 @@ jobs:
           git config --local user.name "github-actions[bot]"
           git checkout -b $BRANCH
           git push -u origin $BRANCH
-          sed -i "s/    'version' => 'canary',/    'version' => '${REF:11}',/" config/app.php
           git add config/app.php
           git commit -m "ci(release): bump version"
           git push

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -63,9 +63,7 @@ jobs:
           tar -czf panel.tar.gz * .env.example
 
       - name: Create checksum
-        run: |
-          SUM=`sha256sum panel.tar.gz`
-          echo $SUM > checksum.txt
+        run: sha256sum panel.tar.gz > checksum.txt
 
       - name: Create release
         id: create_release


### PR DESCRIPTION
Part of the 1.0 versioning work.

The release and docker workflows both sed the canary version out of `config/app.php` with slightly different patterns and no verification, so a formatting drift would silently ship a release that still reports canary. Both now use a shared `stamp-version` composite action that strips a leading v, rejects empty or ref-shaped values, and greps for the stamped line afterwards, failing the build when the replacement did not happen.

The docker workflow references the action from main because scheduled rebuilds check out a release tag that may not contain the action file yet. The first tagged build after this merges is the real end-to-end test.