### PR TITLE
Add an api_version field to plugin.json

### DIFF
--- a/app/Console/Commands/Plugin/MakePluginCommand.php
+++ b/app/Console/Commands/Plugin/MakePluginCommand.php
@@ -4,6 +4,7 @@ namespace App\Console\Commands\Plugin;
 
 use App\Enums\PluginCategory;
 use App\Enums\PluginStatus;
+use App\Models\Plugin;
 use Illuminate\Console\Command;
 use Illuminate\Filesystem\Filesystem;
 use Illuminate\Support\Str;
@@ -111,6 +112,7 @@ class MakePluginCommand extends Command
             'class' => $class,
             'panels' => $panels,
             'panel_version' => $panelVersion,
+            'api_version' => Plugin::SUPPORTED_API_VERSION,
             'composer_packages' => $composerPackages,
             'meta' => [
                 'status' => PluginStatus::Enabled,

--- a/app/Filament/Admin/Resources/Plugins/PluginResource.php
+++ b/app/Filament/Admin/Resources/Plugins/PluginResource.php
@@ -83,6 +83,7 @@ class PluginResource extends Resource
                     ->label(trans('admin/plugin.status'))
                     ->badge()
                     ->tooltip(fn (Plugin $plugin) => $plugin->status_message)
+                    ->description(fn (Plugin $plugin) => is_null($plugin->api_version) ? trans('admin/plugin.api_version_missing') : null)
                     ->sortable(),
             ])
             ->recordActions([

--- a/app/Models/Plugin.php
+++ b/app/Models/Plugin.php
@@ -30,6 +30,7 @@ use Sushi\Sushi;
  * @property string $class
  * @property string|null $panels
  * @property string|null $panel_version
+ * @property int|null $api_version
  * @property string|null $composer_packages
  * @property PluginStatus $status
  * @property string|null $status_message
@@ -61,6 +62,9 @@ class Plugin extends Model implements HasPluginSettings
 
     public const RESOURCE_NAME = 'plugin';
 
+    /** The highest plugin.json api_version this panel supports. */
+    public const SUPPORTED_API_VERSION = 1;
+
     protected $primaryKey = 'id';
 
     protected $keyType = 'string';
@@ -89,6 +93,7 @@ class Plugin extends Model implements HasPluginSettings
             'class' => 'string',
             'panels' => 'string',
             'panel_version' => 'string',
+            'api_version' => 'integer',
             'composer_packages' => 'string',
             'status' => 'string',
             'status_message' => 'string',
@@ -110,6 +115,7 @@ class Plugin extends Model implements HasPluginSettings
      *     class: string,
      *     panels: ?string,
      *     panel_version: ?string,
+     *     api_version: ?int,
      *     composer_packages: ?string,
      *     status: string,
      *     status_message: ?string,
@@ -160,6 +166,7 @@ class Plugin extends Model implements HasPluginSettings
                     'class' => $data['class'],
                     'panels' => $panels,
                     'panel_version' => Arr::get($data, 'panel_version', null),
+                    'api_version' => Arr::get($data, 'api_version', null),
                     'composer_packages' => $composerPackages,
 
                     'status' => Str::lower(Arr::get($data, 'meta.status', PluginStatus::NotInstalled->value)),
@@ -187,6 +194,7 @@ class Plugin extends Model implements HasPluginSettings
                         'class' => 'Error',
                         'panels' => null,
                         'panel_version' => null,
+                        'api_version' => null,
                         'composer_packages' => null,
 
                         'status' => PluginStatus::Errored->value,
@@ -233,6 +241,16 @@ class Plugin extends Model implements HasPluginSettings
         $currentPanelVersion = config('app.version', 'canary');
 
         return !$this->panel_version || $currentPanelVersion === 'canary' || version_compare($currentPanelVersion, str($this->panel_version)->trim('^'), $this->isPanelVersionStrict() ? '=' : '>=');
+    }
+
+    public function effectiveApiVersion(): int
+    {
+        return $this->api_version ?? 1;
+    }
+
+    public function isApiVersionSupported(): bool
+    {
+        return $this->effectiveApiVersion() <= self::SUPPORTED_API_VERSION;
     }
 
     public function isPanelVersionStrict(): bool

--- a/app/Services/Helpers/PluginService.php
+++ b/app/Services/Helpers/PluginService.php
@@ -42,6 +42,13 @@ class PluginService
         $plugins = Plugin::orderBy('load_order')->get();
         foreach ($plugins as $plugin) {
             try {
+                // Filter out plugins that require a newer plugin api than this panel supports
+                if (!$plugin->isApiVersionSupported()) {
+                    $this->setStatus($plugin, PluginStatus::Incompatible, 'This Plugin requires plugin api version ' . $plugin->effectiveApiVersion() . ' but this Panel only supports up to version ' . Plugin::SUPPORTED_API_VERSION . '!');
+
+                    continue;
+                }
+
                 // Filter out plugins that are not compatible with the current panel version
                 if (!$plugin->isCompatible()) {
                     $this->setStatus($plugin, PluginStatus::Incompatible, 'This Plugin is only compatible with Panel version ' . $plugin->panel_version . (!$plugin->isPanelVersionStrict() ? ' or newer' : '') . ' but you are using version ' . config('app.version') . '!');

--- a/lang/en/admin/plugin.php
+++ b/lang/en/admin/plugin.php
@@ -7,6 +7,7 @@ return [
 
     'name' => 'Name',
     'update_available' => 'An update for this plugin is available',
+    'api_version_missing' => '⚠ plugin.json does not declare an api_version, assuming 1',
     'author' => 'Author',
     'version' => 'Version',
     'category' => 'Category',

--- a/tests/Unit/Models/PluginApiVersionTest.php
+++ b/tests/Unit/Models/PluginApiVersionTest.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Tests\Unit\Models;
+
+use App\Models\Plugin;
+use App\Tests\TestCase;
+use PHPUnit\Framework\Attributes\DataProvider;
+
+class PluginApiVersionTest extends TestCase
+{
+    #[DataProvider('apiVersionDataProvider')]
+    public function test_api_version_support(?int $apiVersion, int $expectedEffective, bool $expectedSupported): void
+    {
+        $plugin = new Plugin();
+        $plugin->api_version = $apiVersion;
+
+        $this->assertSame($expectedEffective, $plugin->effectiveApiVersion());
+        $this->assertSame($expectedSupported, $plugin->isApiVersionSupported());
+    }
+
+    public static function apiVersionDataProvider(): array
+    {
+        return [
+            'declared supported version' => [Plugin::SUPPORTED_API_VERSION, Plugin::SUPPORTED_API_VERSION, true],
+            'missing defaults to 1' => [null, 1, true],
+            'newer than supported' => [Plugin::SUPPORTED_API_VERSION + 1, Plugin::SUPPORTED_API_VERSION + 1, false],
+        ];
+    }
+}


### PR DESCRIPTION
Part of the plugin API contract work.

Plugins can declare which plugin api version they target so the panel can refuse to load plugins written against a future incompatible api instead of failing unpredictably. The field is optional and defaults to 1. Plugins declaring a higher version than the panel supports are marked incompatible before loading using the same status flow as the panel_version check, plugins missing the field get a warning note under their status badge on the plugins page, and `p:plugin:make` scaffolds the field.

### Screenshot

<img width="1568" height="248" alt="plugins-api-version" src="https://github.com/user-attachments/assets/4b02e7d4-8136-4ae7-b20a-fffb8e7b687d" />
