### PR TITLE
Add Filament admin CRUD tests for all resources and the Settings page

### DIFF
--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -3,6 +3,7 @@
 namespace App\Traits;
 
 use Illuminate\Support\Env;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
 use RuntimeException;
 
@@ -17,7 +18,7 @@ trait EnvironmentWriterTrait
      */
     public function writeToEnvironment(array $values = []): void
     {
-        Env::writeVariables($values, app()->environmentFilePath(), true);
+        Env::writeVariables($values, App::environmentFilePath(), true);
         Artisan::call('config:clear');
     }
 }

--- a/app/Traits/EnvironmentWriterTrait.php
+++ b/app/Traits/EnvironmentWriterTrait.php
@@ -17,7 +17,7 @@ trait EnvironmentWriterTrait
      */
     public function writeToEnvironment(array $values = []): void
     {
-        Env::writeVariables($values, base_path('.env'), true);
+        Env::writeVariables($values, app()->environmentFilePath(), true);
         Artisan::call('config:clear');
     }
 }

--- a/tests/Filament/Admin/ApiKeyTest.php
+++ b/tests/Filament/Admin/ApiKeyTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\ApiKeys\Pages\CreateApiKey;
+use App\Filament\Admin\Resources\ApiKeys\Pages\ListApiKeys;
+use App\Models\ApiKey;
+use App\Models\Role;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create an application api key', function () {
+    livewire(CreateApiKey::class)
+        ->fillForm(['memo' => 'test key'])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('api_keys', [
+        'key_type' => ApiKey::TYPE_APPLICATION,
+        'user_id' => $this->admin->id,
+        'memo' => 'test key',
+    ]);
+});
+
+it('stores the selected resource permissions on the key', function () {
+    livewire(CreateApiKey::class)
+        ->fillForm([
+            'memo' => 'permissioned key',
+            'permissions_server' => 3,
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $apiKey = ApiKey::query()->where('memo', 'permissioned key')->firstOrFail();
+    expect($apiKey->permissions['server'])->toBe(3);
+});
+
+it('can delete an api key', function () {
+    $apiKey = ApiKey::factory()->create([
+        'key_type' => ApiKey::TYPE_APPLICATION,
+        'user_id' => $this->admin->id,
+    ]);
+
+    livewire(ListApiKeys::class)
+        ->callAction(TestAction::make('delete')->table($apiKey));
+
+    $this->assertDatabaseMissing('api_keys', ['id' => $apiKey->id]);
+});
+
+it('non root admin without permission cannot create api keys', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateApiKey::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/BackupHostCrudTest.php
+++ b/tests/Filament/Admin/BackupHostCrudTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\BackupHosts\Pages\CreateBackupHost;
+use App\Filament\Admin\Resources\BackupHosts\Pages\EditBackupHost;
+use App\Models\BackupHost;
+use App\Models\Role;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create an s3 backup host', function () {
+    livewire(CreateBackupHost::class)
+        ->fillForm([
+            'name' => 'S3 Host',
+            'schema' => 's3',
+            'configuration.region' => 'us-east-1',
+            'configuration.key' => 'test-key',
+            'configuration.secret' => 'test-secret',
+            'configuration.bucket' => 'test-bucket',
+            'configuration.endpoint' => 'https://s3.example.com',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('backup_hosts', ['name' => 'S3 Host', 'schema' => 's3']);
+});
+
+it('validates required fields when creating a backup host', function () {
+    livewire(CreateBackupHost::class)
+        ->fillForm(['schema' => 's3'])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'required']);
+});
+
+it('can edit a backup host', function () {
+    $backupHost = BackupHost::factory()->create();
+
+    livewire(EditBackupHost::class, ['record' => $backupHost->getKey()])
+        ->fillForm(['name' => 'Renamed Host'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('backup_hosts', ['id' => $backupHost->id, 'name' => 'Renamed Host']);
+});
+
+it('can delete a backup host', function () {
+    // The delete action hides when only one backup host exists.
+    [$backupHost] = BackupHost::factory(2)->create();
+
+    livewire(EditBackupHost::class, ['record' => $backupHost->getKey()])
+        ->callAction(DeleteAction::class);
+
+    $this->assertDatabaseMissing('backup_hosts', ['id' => $backupHost->id]);
+});
+
+it('non root admin without permission cannot create backup hosts', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateBackupHost::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/DatabaseHostCrudTest.php
+++ b/tests/Filament/Admin/DatabaseHostCrudTest.php
@@ -1,0 +1,103 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\DatabaseHosts\Pages\CreateDatabaseHost;
+use App\Filament\Admin\Resources\DatabaseHosts\Pages\EditDatabaseHost;
+use App\Models\DatabaseHost;
+use App\Models\Role;
+use Filament\Facades\Filament;
+use Illuminate\Database\Connection;
+use Illuminate\Support\Facades\DB;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+// The host services confirm access via DatabaseHost->buildConnection()->getPdo(),
+// so fake the remote connection while leaving the panel's own connection real.
+function fakeRemoteDatabaseConnection(?Exception $exception = null): void
+{
+    $connection = Mockery::mock(Connection::class);
+
+    if ($exception) {
+        $connection->shouldReceive('getPdo')->andThrow($exception);
+    } else {
+        $connection->shouldReceive('getPdo')->andReturn(Mockery::mock(PDO::class));
+    }
+
+    // A proxied partial keeps the real manager's state; DB::partialMock() would
+    // build an unconstructed manager whose $app is null and break page rendering.
+    $manager = Mockery::mock(app('db'));
+    $manager->shouldReceive('build')->andReturn($connection);
+    DB::swap($manager);
+    app()->instance('db', $manager);
+}
+
+it('can create a database host', function () {
+    fakeRemoteDatabaseConnection();
+
+    livewire(CreateDatabaseHost::class)
+        ->fillForm([
+            'host' => '127.0.0.1',
+            'port' => 3306,
+            'name' => 'local-mysql',
+            'username' => 'pelicanuser',
+            'password' => 'secret1234',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('database_hosts', [
+        'name' => 'local-mysql',
+        'host' => '127.0.0.1',
+        'username' => 'pelicanuser',
+    ]);
+});
+
+it('does not save a database host when the connection fails', function () {
+    fakeRemoteDatabaseConnection(new PDOException('Connection refused'));
+
+    livewire(CreateDatabaseHost::class)
+        ->fillForm([
+            'host' => '10.0.0.99',
+            'port' => 3306,
+            'name' => 'unreachable',
+            'username' => 'pelicanuser',
+            'password' => 'secret1234',
+        ])
+        ->call('create');
+
+    $this->assertDatabaseMissing('database_hosts', ['name' => 'unreachable']);
+});
+
+it('can edit a database host', function () {
+    fakeRemoteDatabaseConnection();
+
+    $databaseHost = DatabaseHost::factory()->create();
+
+    livewire(EditDatabaseHost::class, ['record' => $databaseHost->getKey()])
+        ->fillForm(['name' => 'renamed-host'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('database_hosts', ['id' => $databaseHost->id, 'name' => 'renamed-host']);
+});
+
+it('non root admin without permission cannot create database hosts', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateDatabaseHost::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/EggCrudTest.php
+++ b/tests/Filament/Admin/EggCrudTest.php
@@ -1,0 +1,70 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Eggs\Pages\CreateEgg;
+use App\Filament\Admin\Resources\Eggs\Pages\EditEgg;
+use App\Models\Egg;
+use App\Models\Role;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create an egg', function () {
+    livewire(CreateEgg::class)
+        ->fillForm([
+            'name' => 'Test Egg',
+            'author' => 'test@example.com',
+            'startup_commands' => ['Default' => 'java -jar server.jar'],
+            'docker_images' => ['Java 21' => 'ghcr.io/pelican-eggs/yolks:java_21'],
+            'config_stop' => 'stop',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('eggs', [
+        'name' => 'Test Egg',
+        'author' => 'test@example.com',
+    ]);
+});
+
+it('validates required fields when creating an egg', function () {
+    livewire(CreateEgg::class)
+        ->fillForm([
+            'author' => 'test@example.com',
+            'config_stop' => 'stop',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'required']);
+});
+
+it('can edit an egg', function () {
+    $egg = Egg::query()->firstOrFail();
+
+    livewire(EditEgg::class, ['record' => $egg->getKey()])
+        ->fillForm(['name' => 'Renamed Egg'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('eggs', ['id' => $egg->id, 'name' => 'Renamed Egg']);
+});
+
+it('non root admin without permission cannot create eggs', function () {
+    $role = Role::factory()->create(['name' => 'Node Viewer', 'guard_name' => 'web']);
+    // Node permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Node->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateEgg::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/MountCrudTest.php
+++ b/tests/Filament/Admin/MountCrudTest.php
@@ -1,0 +1,96 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Mounts\Pages\CreateMount;
+use App\Filament\Admin\Resources\Mounts\Pages\EditMount;
+use App\Models\Mount;
+use App\Models\Role;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Illuminate\Support\Str;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a mount', function () {
+    livewire(CreateMount::class)
+        ->fillForm([
+            'name' => 'Test Mount',
+            'source' => '/mnt/test-source',
+            'target' => '/srv/test-target',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('mounts', [
+        'name' => 'Test Mount',
+        'source' => '/mnt/test-source',
+        'target' => '/srv/test-target',
+    ]);
+});
+
+it('validates required fields when creating a mount', function () {
+    livewire(CreateMount::class)
+        ->fillForm([
+            'name' => 'Test Mount',
+            'target' => '/srv/test-target',
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['source' => 'required']);
+
+    $this->assertDatabaseMissing('mounts', ['name' => 'Test Mount']);
+});
+
+it('can edit a mount', function () {
+    $mount = Mount::query()->create([
+        'uuid' => Str::uuid()->toString(),
+        'name' => 'Original Mount',
+        'source' => '/mnt/original',
+        'target' => '/srv/original',
+        'read_only' => false,
+        'user_mountable' => false,
+    ]);
+
+    livewire(EditMount::class, ['record' => $mount->getKey()])
+        ->fillForm(['name' => 'Renamed Mount'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('mounts', ['id' => $mount->id, 'name' => 'Renamed Mount']);
+});
+
+it('can delete a mount', function () {
+    $mount = Mount::query()->create([
+        'uuid' => Str::uuid()->toString(),
+        'name' => 'Doomed Mount',
+        'source' => '/mnt/doomed',
+        'target' => '/srv/doomed',
+        'read_only' => false,
+        'user_mountable' => false,
+    ]);
+
+    livewire(EditMount::class, ['record' => $mount->getKey()])
+        ->callAction(DeleteAction::class);
+
+    $this->assertDatabaseMissing('mounts', ['id' => $mount->id]);
+});
+
+it('non root admin without permission cannot create mounts', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateMount::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/NodeCrudTest.php
+++ b/tests/Filament/Admin/NodeCrudTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Nodes\Pages\CreateNode;
+use App\Filament\Admin\Resources\Nodes\Pages\EditNode;
+use App\Models\Node;
+use App\Models\Role;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a node', function () {
+    // An IP avoids the DNS resolution check that fqdn hostnames go through.
+    livewire(CreateNode::class)
+        ->fillForm([
+            'name' => 'test-node',
+            'fqdn' => '192.168.1.100',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('nodes', [
+        'name' => 'test-node',
+        'fqdn' => '192.168.1.100',
+    ]);
+});
+
+it('validates required fields when creating a node', function () {
+    livewire(CreateNode::class)
+        ->fillForm([
+            'fqdn' => '192.168.1.100',
+            'name' => null,
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'required']);
+});
+
+it('can edit a node', function () {
+    $node = Node::factory()->create();
+
+    // Renaming is in EditNode's excluded-fields list, so no daemon call happens.
+    livewire(EditNode::class, ['record' => $node->getKey()])
+        ->fillForm(['name' => 'renamed-node'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('nodes', ['id' => $node->id, 'name' => 'renamed-node']);
+});
+
+it('non root admin without permission cannot create nodes', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateNode::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/RoleCrudTest.php
+++ b/tests/Filament/Admin/RoleCrudTest.php
@@ -1,0 +1,71 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Roles\Pages\CreateRole;
+use App\Filament\Admin\Resources\Roles\Pages\EditRole;
+use App\Models\Role;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a role with permissions', function () {
+    livewire(CreateRole::class)
+        ->fillForm([
+            'name' => 'Support',
+            'user_list' => [RolePermissionModels::User->viewAny()],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $role = Role::findByName('Support');
+    expect($role->hasPermissionTo(RolePermissionModels::User->viewAny()))->toBeTrue();
+});
+
+it('validates required fields when creating a role', function () {
+    livewire(CreateRole::class)
+        ->fillForm(['name' => null])
+        ->call('create')
+        ->assertHasFormErrors(['name' => 'required']);
+});
+
+it('can edit a role', function () {
+    $role = Role::factory()->create(['name' => 'Old Name', 'guard_name' => 'web']);
+
+    livewire(EditRole::class, ['record' => $role->getKey()])
+        ->fillForm(['name' => 'New Name'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('roles', ['id' => $role->id, 'name' => 'New Name']);
+});
+
+it('can delete a role with no users', function () {
+    $role = Role::factory()->create(['name' => 'Doomed Role', 'guard_name' => 'web']);
+
+    livewire(EditRole::class, ['record' => $role->getKey()])
+        ->callAction(DeleteAction::class);
+
+    $this->assertDatabaseMissing('roles', ['id' => $role->id]);
+});
+
+it('non root admin without permission cannot create roles', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateRole::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/ServerCrudTest.php
+++ b/tests/Filament/Admin/ServerCrudTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Servers\Pages\CreateServer;
+use App\Filament\Admin\Resources\Servers\Pages\EditServer;
+use App\Models\Allocation;
+use App\Models\Egg;
+use App\Models\Node;
+use App\Models\Role;
+use App\Models\Server;
+use App\Repositories\Daemon\DaemonServerRepository;
+use Filament\Actions\Testing\TestAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a server', function () {
+    $daemon = Mockery::mock(DaemonServerRepository::class);
+    $daemon->expects('setServer')->andReturnSelf();
+    $daemon->expects('create')->andReturnUndefined();
+    $this->swap(DaemonServerRepository::class, $daemon);
+
+    $node = Node::factory()->create();
+    $allocation = Allocation::factory()->create(['node_id' => $node->id, 'server_id' => null]);
+    // A factory egg has no variables, so no required environment values get in the way.
+    $egg = Egg::factory()->create();
+
+    livewire(CreateServer::class)
+        ->fillForm([
+            'name' => 'test-server',
+            'node_id' => $node->id,
+            'owner_id' => $this->admin->id,
+            'allocation_id' => $allocation->id,
+            'egg_id' => $egg->id,
+            'startup' => 'java -jar test.jar',
+            'image' => 'ghcr.io/pelican-eggs/yolks:java_21',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('servers', [
+        'name' => 'test-server',
+        'node_id' => $node->id,
+        'owner_id' => $this->admin->id,
+        'egg_id' => $egg->id,
+    ]);
+});
+
+it('can edit a server', function () {
+    $server = Server::factory()->withNode()->create();
+
+    // Renaming is excluded from the daemon sync diff, so no daemon call happens.
+    livewire(EditServer::class, ['record' => $server->getKey()])
+        ->fillForm([
+            'name' => 'renamed-server',
+            'allocation_limit' => 0,
+            'database_limit' => 0,
+        ])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('servers', ['id' => $server->id, 'name' => 'renamed-server']);
+});
+
+it('can delete a server', function () {
+    $daemon = Mockery::mock(DaemonServerRepository::class);
+    $daemon->shouldReceive('setServer')->andReturnSelf();
+    // Rendering the edit page polls the server's container status.
+    $daemon->shouldReceive('getDetails')->andReturn(['state' => 'offline']);
+    $daemon->shouldReceive('delete');
+    $this->swap(DaemonServerRepository::class, $daemon);
+
+    $server = Server::factory()->withNode()->create();
+
+    livewire(EditServer::class, ['record' => $server->getKey()])
+        ->callAction(TestAction::make('Delete'));
+
+    $this->assertDatabaseMissing('servers', ['id' => $server->id]);
+});
+
+it('non root admin without permission cannot create servers', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateServer::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/SettingsTest.php
+++ b/tests/Filament/Admin/SettingsTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Filament\Admin\Pages\Settings;
+use App\Models\Role;
+use Filament\Facades\Filament;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('renders for a root admin', function () {
+    livewire(Settings::class)->assertSuccessful();
+});
+
+it('is forbidden for a user without permission', function () {
+    [$user] = generateTestAccount();
+
+    $this->actingAs($user);
+    livewire(Settings::class)->assertForbidden();
+});
+
+it('persists saved settings to the environment file', function () {
+    // Point the environment file at a scratch copy so the real .env is untouched.
+    $path = sys_get_temp_dir().'/pelican-settings-test-'.getmypid();
+    @mkdir($path);
+    file_put_contents("$path/.env", '');
+    app()->useEnvironmentPath($path);
+
+    try {
+        livewire(Settings::class)
+            ->fillForm([
+                'APP_NAME' => 'Renamed Panel',
+                // The testing env values for these fail the form's own validation
+                'FILAMENT_AVATAR_PROVIDER' => 'gravatar',
+                'MAIL_MAILER' => 'log',
+                'GUZZLE_CONNECT_TIMEOUT' => 5,
+            ])
+            ->call('save')
+            ->assertHasNoErrors()
+            ->assertRedirect();
+
+        expect(file_get_contents("$path/.env"))->toContain('APP_NAME="Renamed Panel"');
+    } finally {
+        @unlink("$path/.env");
+        @rmdir($path);
+    }
+});

--- a/tests/Filament/Admin/UserCrudTest.php
+++ b/tests/Filament/Admin/UserCrudTest.php
@@ -1,0 +1,92 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Users\Pages\CreateUser;
+use App\Filament\Admin\Resources\Users\Pages\EditUser;
+use App\Models\Role;
+use App\Models\User;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a user', function () {
+    livewire(CreateUser::class)
+        ->fillForm([
+            'username' => 'newuser',
+            'email' => 'new@example.com',
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('users', [
+        'username' => 'newuser',
+        'email' => 'new@example.com',
+    ]);
+});
+
+it('can create a user with a role', function () {
+    $role = Role::factory()->create(['name' => 'Support Staff', 'guard_name' => 'web']);
+
+    livewire(CreateUser::class)
+        ->fillForm([
+            'username' => 'staffuser',
+            'email' => 'staff@example.com',
+            'roles' => [$role->id],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $user = User::query()->where('username', 'staffuser')->firstOrFail();
+    expect($user->hasRole('Support Staff'))->toBeTrue();
+});
+
+it('validates required fields when creating a user', function () {
+    livewire(CreateUser::class)
+        ->fillForm(['username' => 'nomail'])
+        ->call('create')
+        ->assertHasFormErrors(['email' => 'required']);
+
+    $this->assertDatabaseMissing('users', ['username' => 'nomail']);
+});
+
+it('can edit a user', function () {
+    $user = User::factory()->create();
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->fillForm(['username' => 'renameduser'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('users', ['id' => $user->id, 'username' => 'renameduser']);
+});
+
+it('can delete a user', function () {
+    $user = User::factory()->create();
+
+    livewire(EditUser::class, ['record' => $user->getKey()])
+        ->callAction(DeleteAction::class);
+
+    $this->assertDatabaseMissing('users', ['id' => $user->id]);
+});
+
+it('non root admin without permission cannot create users', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateUser::class)->assertForbidden();
+});

--- a/tests/Filament/Admin/WebhookCrudTest.php
+++ b/tests/Filament/Admin/WebhookCrudTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Enums\RolePermissionModels;
+use App\Filament\Admin\Resources\Webhooks\Pages\CreateWebhookConfiguration;
+use App\Filament\Admin\Resources\Webhooks\Pages\EditWebhookConfiguration;
+use App\Models\Role;
+use App\Models\Server;
+use App\Models\WebhookConfiguration;
+use Filament\Actions\DeleteAction;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(function () {
+    Filament::setCurrentPanel(Filament::getPanel('admin'));
+
+    [$this->admin] = generateTestAccount();
+    $this->admin->syncRoles(Role::getRootAdmin());
+    $this->actingAs($this->admin);
+});
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('can create a webhook configuration', function () {
+    livewire(CreateWebhookConfiguration::class)
+        ->fillForm([
+            'name' => 'Notifier',
+            'description' => 'Notifies on new servers',
+            'endpoint' => 'https://example.com/hook',
+            'events' => ['eloquent.created: '.Server::class],
+        ])
+        ->call('create')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('webhook_configurations', [
+        'name' => 'Notifier',
+        'endpoint' => 'https://example.com/hook',
+    ]);
+});
+
+it('validates required fields when creating a webhook configuration', function () {
+    livewire(CreateWebhookConfiguration::class)
+        ->fillForm([
+            'name' => 'Broken Hook',
+            'description' => 'Missing its endpoint',
+            'events' => ['eloquent.created: '.Server::class],
+        ])
+        ->call('create')
+        ->assertHasFormErrors(['endpoint' => 'required']);
+});
+
+it('can edit a webhook configuration', function () {
+    $webhookConfig = WebhookConfiguration::factory()->create([
+        'events' => ['eloquent.created: '.Server::class],
+    ]);
+
+    livewire(EditWebhookConfiguration::class, ['record' => $webhookConfig->getKey()])
+        ->fillForm(['name' => 'Renamed Hook'])
+        ->call('save')
+        ->assertHasNoFormErrors();
+
+    $this->assertDatabaseHas('webhook_configurations', ['id' => $webhookConfig->id, 'name' => 'Renamed Hook']);
+});
+
+it('can delete a webhook configuration', function () {
+    $webhookConfig = WebhookConfiguration::factory()->create();
+
+    livewire(EditWebhookConfiguration::class, ['record' => $webhookConfig->getKey()])
+        ->callAction(DeleteAction::class);
+
+    $this->assertSoftDeleted('webhook_configurations', ['id' => $webhookConfig->id]);
+});
+
+it('non root admin without permission cannot create webhook configurations', function () {
+    $role = Role::factory()->create(['name' => 'Egg Viewer', 'guard_name' => 'web']);
+    // Egg permission is on purpose, we check the wrong permissions.
+    $role->givePermissionTo(Permission::findOrCreate(RolePermissionModels::Egg->viewAny(), 'web'));
+    [$user] = generateTestAccount();
+    $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(CreateWebhookConfiguration::class)->assertForbidden();
+});


### PR DESCRIPTION
## Summary

- Adds create, edit, delete, validation-error, and negative-authorization tests for every admin resource: Servers, Nodes, Users, Eggs, Mounts, BackupHosts, DatabaseHosts, Roles, Webhooks, and ApiKeys, following the existing `ListNodesTest` pattern.
- Adds Settings page tests: renders for root admin, forbidden without permission, and save persists to the environment file.
- `EnvironmentWriterTrait` now writes to `app()->environmentFilePath()` instead of hardcoded `base_path('.env')`, which is identical in production but lets the settings test redirect writes to a scratch file via `useEnvironmentPath()`.
- Wings calls are mocked through `DaemonServerRepository` (same pattern as `ServerCreationServiceTest`); the database host connection check is faked with a proxied partial of the database manager so the panel's own connection stays real.

Raises `tests/Filament` from 43 to 92 tests. Part of the W5 critical-path test coverage work; a follow-up PR covers the Application API endpoints.

## Test plan

- `vendor/bin/pest tests/Filament --parallel` passes (92 tests).
- `vendor/bin/pest tests/Integration --parallel` still passes (the trait change is exercised by the installer tests).