### PR TITLE
Add Dependabot, dependency-audit CI, and refresh SECURITY.md

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,26 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      composer:
+        patterns:
+          - "*"
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      npm:
+        patterns:
+          - "*"
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -23,7 +23,7 @@ jobs:
           coverage: none
 
       - name: Composer Audit
-        run: composer audit --no-interaction
+        run: composer audit --locked --no-interaction
 
   yarn-audit:
     name: Yarn Audit

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -1,0 +1,36 @@
+name: Security Audit
+
+on:
+  pull_request:
+    branches:
+      - "**"
+  schedule:
+    - cron: "0 6 * * 1"
+
+jobs:
+  composer-audit:
+    name: Composer Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: "8.5"
+          tools: composer:v2
+          coverage: none
+
+      - name: Composer Audit
+        run: composer audit --no-interaction
+
+  yarn-audit:
+    name: Yarn Audit
+    runs-on: ubuntu-latest
+    steps:
+      - name: Code Checkout
+        uses: actions/checkout@v6
+
+      - name: Yarn Audit
+        run: yarn audit --level high

--- a/.github/workflows/security-audit.yaml
+++ b/.github/workflows/security-audit.yaml
@@ -33,4 +33,8 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Yarn Audit
-        run: yarn audit --level high
+        # Yarn classic's exit code is a bitmask (8 = high, 16 = critical);
+        # --level only filters the output, so mask the code to match it.
+        run: |
+          yarn audit --level high || code=$?
+          exit $(( ${code:-0} & 24 ? 1 : 0 ))

--- a/security.md
+++ b/security.md
@@ -2,7 +2,7 @@
 
 ## Supported Versions
 
-While Pelican is in beta, we only provide security fixes for the most recent beta release. Older beta releases are unsupported.  
+We only provide security fixes for the most recent release. Older releases are unsupported; upgrade to receive fixes.  
 ![](https://img.shields.io/github/v/release/pelican/panel?label=latest-release)
 
 ## Reporting a Vulnerability


### PR DESCRIPTION
Adds `.github/dependabot.yml` (composer, npm, github-actions; weekly, grouped) and a security-audit workflow running `composer audit` and `yarn audit --level high` on PRs and weekly. Both audits are currently clean locally, so the workflow starts blocking with a clean baseline.