### PR TITLE
Make activity logs append-only at the model layer

### DIFF
--- a/app/Models/ActivityLog.php
+++ b/app/Models/ActivityLog.php
@@ -158,6 +158,11 @@ class ActivityLog extends Model implements HasIcon, HasLabel
             $model->timestamp = Carbon::now();
         });
 
+        // Activity logs are append-only. Pruning still works because MassPrunable
+        // deletes through the query builder and never fires these model events;
+        // switching to the non-mass Prunable trait would break it.
+        static::updating(fn () => throw new LogicException('Activity logs are append-only and cannot be updated.'));
+        static::deleting(fn () => throw new LogicException('Activity logs are append-only and cannot be deleted.'));
     }
 
     public function getIcon(): BackedEnum

--- a/tests/Integration/ActivityLogImmutabilityTest.php
+++ b/tests/Integration/ActivityLogImmutabilityTest.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Tests\Integration;
+
+use App\Models\ActivityLog;
+use Illuminate\Support\Facades\DB;
+use LogicException;
+
+class ActivityLogImmutabilityTest extends IntegrationTestCase
+{
+    public function test_activity_log_cannot_be_updated(): void
+    {
+        $log = ActivityLog::create(['event' => 'test:event', 'ip' => '127.0.0.1', 'properties' => []]);
+
+        $this->expectException(LogicException::class);
+
+        $log->update(['event' => 'test:tampered']);
+    }
+
+    public function test_activity_log_cannot_be_deleted(): void
+    {
+        $log = ActivityLog::create(['event' => 'test:event', 'ip' => '127.0.0.1', 'properties' => []]);
+
+        $this->expectException(LogicException::class);
+
+        $log->delete();
+    }
+
+    public function test_mass_pruning_still_deletes_old_logs(): void
+    {
+        $old = ActivityLog::create(['event' => 'test:old', 'ip' => '127.0.0.1', 'properties' => []]);
+        $recent = ActivityLog::create(['event' => 'test:recent', 'ip' => '127.0.0.1', 'properties' => []]);
+
+        // Age the record through the query builder since the model layer is append-only.
+        DB::table('activity_logs')->where('id', $old->id)->update([
+            'timestamp' => now()->subDays(config('activity.prune_days') + 1),
+        ]);
+
+        $this->artisan('model:prune', ['--model' => ActivityLog::class]);
+
+        $this->assertDatabaseMissing('activity_logs', ['id' => $old->id]);
+        $this->assertDatabaseHas('activity_logs', ['id' => $recent->id]);
+    }
+}


### PR DESCRIPTION
Adds `updating`/`deleting` guards to `ActivityLog::boot()` that throw, so audit entries can't be tampered with through the model. Pruning is unaffected because `MassPrunable` deletes through the query builder without firing model events; a comment documents that coupling. The `activity_log_subjects` FK already cascades, so pruning leaves no orphans.