### PR TITLE
Add admin-wide activity viewer behind a new view activityLog permission

### DIFF
--- a/app/Filament/Admin/Resources/Activities/ActivityResource.php
+++ b/app/Filament/Admin/Resources/Activities/ActivityResource.php
@@ -78,6 +78,15 @@ class ActivityResource extends Resource
             ->defaultSort('timestamp', 'desc')
             ->recordActions([
                 ViewAction::make()
+                    // Flatten before the form fills: KeyValue's state cast mistakes a nested
+                    // assoc (first value an array) for its own row format and blanks it.
+                    ->mutateRecordDataUsing(function (array $data) {
+                        $data['properties'] = collect(Arr::dot($data['properties'] ?? []))
+                            ->map(fn ($value) => is_bool($value) || is_null($value) ? var_export($value, true) : $value)
+                            ->all();
+
+                        return $data;
+                    })
                     ->schema([
                         TextEntry::make('event')
                             ->label(trans('admin/activity.event'))
@@ -93,8 +102,7 @@ class ActivityResource extends Resource
                         DateTimePicker::make('timestamp')
                             ->label(trans('admin/activity.timestamp')),
                         KeyValue::make('properties')
-                            ->label(trans('admin/activity.metadata'))
-                            ->formatStateUsing(fn ($state) => Arr::dot($state)),
+                            ->label(trans('admin/activity.metadata')),
                     ]),
             ])
             ->filters([

--- a/app/Filament/Admin/Resources/Activities/ActivityResource.php
+++ b/app/Filament/Admin/Resources/Activities/ActivityResource.php
@@ -25,7 +25,9 @@ use Filament\Tables\Columns\TextColumn;
 use Filament\Tables\Filters\Filter;
 use Filament\Tables\Filters\SelectFilter;
 use Filament\Tables\Table;
+use Illuminate\Auth\Access\Response;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Model;
 use Illuminate\Support\Arr;
 use Illuminate\Support\HtmlString;
 
@@ -128,7 +130,8 @@ class ActivityResource extends Resource
     {
         // Deliberately unscoped (and ignoring activity.hide_admin_activity):
         // this is the panel-wide audit view for admins holding "view activityLog".
-        return ActivityLog::whereNotIn('event', ActivityLog::DISABLED_EVENTS);
+        return ActivityLog::with(['actor', 'apiKey'])
+            ->whereNotIn('event', ActivityLog::DISABLED_EVENTS);
     }
 
     public static function canViewAny(): bool
@@ -139,6 +142,15 @@ class ActivityResource extends Resource
     public static function canAccess(): bool
     {
         return static::canViewAny();
+    }
+
+    /**
+     * ActivityLogPolicy::view() checks the server-panel subuser permission,
+     * which never applies here; the admin viewer is gated by "view activityLog".
+     */
+    public static function getViewAuthorizationResponse(Model $record): Response
+    {
+        return static::canViewAny() ? Response::allow() : Response::deny();
     }
 
     /** @return array<string, PageRegistration> */

--- a/app/Filament/Admin/Resources/Activities/ActivityResource.php
+++ b/app/Filament/Admin/Resources/Activities/ActivityResource.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Activities;
+
+use App\Enums\TablerIcon;
+use App\Filament\Admin\Resources\Activities\Pages\ListActivities;
+use App\Filament\Admin\Resources\Users\Pages\EditUser;
+use App\Filament\Components\Tables\Columns\DateTimeColumn;
+use App\Models\ActivityLog;
+use App\Models\ActivityLogSubject;
+use App\Models\User;
+use App\Traits\Filament\CanCustomizePages;
+use App\Traits\Filament\CanCustomizeRelations;
+use App\Traits\Filament\CanModifyTable;
+use BackedEnum;
+use Exception;
+use Filament\Actions\ViewAction;
+use Filament\Forms\Components\DateTimePicker;
+use Filament\Forms\Components\KeyValue;
+use Filament\Forms\Components\TextInput;
+use Filament\Infolists\Components\TextEntry;
+use Filament\Resources\Pages\PageRegistration;
+use Filament\Resources\Resource;
+use Filament\Tables\Columns\TextColumn;
+use Filament\Tables\Filters\Filter;
+use Filament\Tables\Filters\SelectFilter;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Support\Arr;
+use Illuminate\Support\HtmlString;
+
+class ActivityResource extends Resource
+{
+    use CanCustomizePages;
+    use CanCustomizeRelations;
+    use CanModifyTable;
+
+    protected static ?string $model = ActivityLog::class;
+
+    protected static string|BackedEnum|null $navigationIcon = TablerIcon::Stack;
+
+    /**
+     * @throws Exception
+     */
+    public static function defaultTable(Table $table): Table
+    {
+        return $table
+            ->paginated([25, 50])
+            ->defaultPaginationPageOption(25)
+            ->columns([
+                TextColumn::make('event')
+                    ->label(trans('admin/activity.event'))
+                    ->html()
+                    ->description(fn ($state) => $state)
+                    ->icon(fn (ActivityLog $activityLog) => $activityLog->getIcon())
+                    ->formatStateUsing(fn (ActivityLog $activityLog) => $activityLog->getLabel()),
+                TextColumn::make('user')
+                    ->label(trans('admin/activity.user'))
+                    ->state(fn (ActivityLog $activityLog) => self::actorName($activityLog))
+                    ->tooltip(fn (ActivityLog $activityLog) => $activityLog->getIp() ?? '')
+                    ->url(fn (ActivityLog $activityLog) => $activityLog->actor instanceof User && user()?->can('update', $activityLog->actor) ? EditUser::getUrl(['record' => $activityLog->actor]) : '')
+                    ->grow(false),
+                TextColumn::make('subjects')
+                    ->label(trans('admin/activity.subject'))
+                    ->state(fn (ActivityLog $activityLog) => $activityLog->subjects
+                        ->map(fn (ActivityLogSubject $subject) => class_basename($subject->subject_type) . ' #' . $subject->subject_id)
+                        ->unique()
+                        ->join(', '))
+                    ->grow(false),
+                DateTimeColumn::make('timestamp')
+                    ->label(trans('admin/activity.timestamp'))
+                    ->since()
+                    ->sortable()
+                    ->grow(false),
+            ])
+            ->defaultSort('timestamp', 'desc')
+            ->recordActions([
+                ViewAction::make()
+                    ->schema([
+                        TextEntry::make('event')
+                            ->label(trans('admin/activity.event'))
+                            ->state(fn (ActivityLog $activityLog) => new HtmlString($activityLog->getLabel())),
+                        TextInput::make('user')
+                            ->label(trans('admin/activity.user'))
+                            ->formatStateUsing(function (ActivityLog $activityLog) {
+                                $user = self::actorName($activityLog);
+                                $ip = $activityLog->getIp();
+
+                                return $ip ? "$user - $ip" : $user;
+                            }),
+                        DateTimePicker::make('timestamp')
+                            ->label(trans('admin/activity.timestamp')),
+                        KeyValue::make('properties')
+                            ->label(trans('admin/activity.metadata'))
+                            ->formatStateUsing(fn ($state) => Arr::dot($state)),
+                    ]),
+            ])
+            ->filters([
+                SelectFilter::make('event')
+                    ->label(trans('admin/activity.event'))
+                    ->options(fn () => ActivityLog::whereNotIn('event', ActivityLog::DISABLED_EVENTS)->select('event')->distinct()->orderBy('event')->pluck('event', 'event'))
+                    ->searchable()
+                    ->preload(),
+                SelectFilter::make('actor_id')
+                    ->label(trans('admin/activity.user'))
+                    ->options(fn () => User::whereIn('id', ActivityLog::whereNotNull('actor_id')->select('actor_id'))->pluck('username', 'id'))
+                    ->searchable()
+                    ->preload(),
+                SelectFilter::make('subject_type')
+                    ->label(trans('admin/activity.subject'))
+                    ->options(fn () => ActivityLogSubject::select('subject_type')->distinct()->orderBy('subject_type')->pluck('subject_type', 'subject_type')->mapWithKeys(fn ($type) => [$type => class_basename($type)]))
+                    ->query(fn (Builder $query, array $data) => $query->when($data['value'], fn (Builder $query, $value) => $query->whereHas('subjects', fn (Builder $query) => $query->where('subject_type', $value)))),
+                Filter::make('timestamp')
+                    ->schema([
+                        DateTimePicker::make('from')
+                            ->label(trans('admin/activity.from')),
+                        DateTimePicker::make('until')
+                            ->label(trans('admin/activity.until')),
+                    ])
+                    ->query(fn (Builder $query, array $data) => $query
+                        ->when($data['from'], fn (Builder $query, $value) => $query->where('timestamp', '>=', $value))
+                        ->when($data['until'], fn (Builder $query, $value) => $query->where('timestamp', '<=', $value))),
+            ]);
+    }
+
+    /** @return Builder<ActivityLog> */
+    public static function getEloquentQuery(): Builder
+    {
+        // Deliberately unscoped (and ignoring activity.hide_admin_activity):
+        // this is the panel-wide audit view for admins holding "view activityLog".
+        return ActivityLog::whereNotIn('event', ActivityLog::DISABLED_EVENTS);
+    }
+
+    public static function canViewAny(): bool
+    {
+        return user()?->can('view activityLog') ?? false;
+    }
+
+    public static function canAccess(): bool
+    {
+        return static::canViewAny();
+    }
+
+    /** @return array<string, PageRegistration> */
+    public static function getDefaultPages(): array
+    {
+        return [
+            'index' => ListActivities::route('/'),
+        ];
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return trans('admin/activity.title');
+    }
+
+    public static function getNavigationGroup(): ?string
+    {
+        return trans('admin/dashboard.advanced');
+    }
+
+    private static function actorName(ActivityLog $activityLog): string
+    {
+        if (!$activityLog->actor instanceof User) {
+            return $activityLog->actor_id === null ? trans('admin/activity.system') : trans('admin/activity.deleted_user');
+        }
+
+        return "{$activityLog->actor->username} ({$activityLog->actor->email})";
+    }
+}

--- a/app/Filament/Admin/Resources/Activities/Pages/ListActivities.php
+++ b/app/Filament/Admin/Resources/Activities/Pages/ListActivities.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Filament\Admin\Resources\Activities\Pages;
+
+use App\Filament\Admin\Resources\Activities\ActivityResource;
+use App\Traits\Filament\CanCustomizeHeaderActions;
+use App\Traits\Filament\CanCustomizeHeaderWidgets;
+use Filament\Resources\Pages\ListRecords;
+
+class ListActivities extends ListRecords
+{
+    use CanCustomizeHeaderActions;
+    use CanCustomizeHeaderWidgets;
+
+    protected static string $resource = ActivityResource::class;
+
+    public function getTitle(): string
+    {
+        return trans('admin/activity.title');
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -65,6 +65,7 @@ class Role extends BaseRole
             'view',
         ],
         'activityLog' => [
+            'view',
             'seeIps',
         ],
         'panelLog' => [

--- a/lang/en/admin/activity.php
+++ b/lang/en/admin/activity.php
@@ -1,0 +1,14 @@
+<?php
+
+return [
+    'title' => 'Activity',
+    'event' => 'Event',
+    'user' => 'User',
+    'deleted_user' => 'Deleted User',
+    'system' => 'System',
+    'subject' => 'Subject',
+    'timestamp' => 'Timestamp',
+    'metadata' => 'Metadata',
+    'from' => 'From',
+    'until' => 'Until',
+];

--- a/tests/Filament/Admin/ListActivitiesTest.php
+++ b/tests/Filament/Admin/ListActivitiesTest.php
@@ -66,6 +66,19 @@ it('user with view activityLog can see the viewer', function () {
         ->assertCountTableRecords(ActivityLog::count());
 });
 
+it('flattens nested properties for the metadata modal', function () {
+    [$admin] = generateTestAccount([]);
+    $admin = $admin->syncRoles(Role::getRootAdmin());
+
+    // Nested-only properties trip KeyValue's state cast without the flatten.
+    $log = Activity::event('settings:update')->property('changes', ['APP_NAME' => ['old' => 'A', 'new' => null]])->log();
+
+    $this->actingAs($admin);
+    livewire(ListActivities::class)
+        ->mountAction(TestAction::make('view')->table($log))
+        ->assertActionDataSet(['properties' => ['changes.APP_NAME.old' => 'A', 'changes.APP_NAME.new' => 'NULL']]);
+});
+
 it('user with view activityLog can open the properties modal', function () {
     $role = Role::factory()->create(['name' => 'Modal Auditor', 'guard_name' => 'web']);
     $role->givePermissionTo(Permission::findOrCreate('view activityLog', 'web'));

--- a/tests/Filament/Admin/ListActivitiesTest.php
+++ b/tests/Filament/Admin/ListActivitiesTest.php
@@ -1,0 +1,66 @@
+<?php
+
+use App\Facades\Activity;
+use App\Filament\Admin\Resources\Activities\Pages\ListActivities;
+use App\Models\ActivityLog;
+use App\Models\Role;
+use Filament\Facades\Filament;
+use Spatie\Permission\Models\Permission;
+
+use function Pest\Livewire\livewire;
+
+beforeEach(fn () => Filament::setCurrentPanel(Filament::getPanel('admin')));
+afterEach(fn () => Filament::setCurrentPanel(null));
+
+it('root admin can see activity from every panel', function () {
+    [$admin, $server] = generateTestAccount([]);
+    $admin = $admin->syncRoles(Role::getRootAdmin());
+
+    Activity::event('auth:success')->actor($admin)->log();
+    Activity::event('server:power.start')->subject($server)->log();
+
+    $this->actingAs($admin);
+    livewire(ListActivities::class)
+        ->assertSuccessful()
+        ->assertCountTableRecords(ActivityLog::count())
+        ->assertCanSeeTableRecords(ActivityLog::all());
+});
+
+it('event filter narrows the table', function () {
+    [$admin] = generateTestAccount([]);
+    $admin = $admin->syncRoles(Role::getRootAdmin());
+
+    Activity::event('auth:success')->actor($admin)->log();
+    Activity::event('auth:fail')->log();
+
+    $this->actingAs($admin);
+    livewire(ListActivities::class)
+        ->filterTable('event', 'auth:fail')
+        ->assertCountTableRecords(1);
+});
+
+it('user without view activityLog is forbidden', function () {
+    $role = Role::factory()->create(['name' => 'IP Viewer', 'guard_name' => 'web']);
+    // seeIps alone must not grant access to the viewer.
+    $role->givePermissionTo(Permission::findOrCreate('seeIps activityLog', 'web'));
+    [$user] = generateTestAccount([]);
+    $user = $user->syncRoles($role);
+
+    $this->actingAs($user);
+    livewire(ListActivities::class)
+        ->assertForbidden();
+});
+
+it('user with view activityLog can see the viewer', function () {
+    $role = Role::factory()->create(['name' => 'Auditor', 'guard_name' => 'web']);
+    $role->givePermissionTo(Permission::findOrCreate('view activityLog', 'web'));
+    [$user] = generateTestAccount([]);
+    $user = $user->syncRoles($role);
+
+    Activity::event('auth:success')->log();
+
+    $this->actingAs($user);
+    livewire(ListActivities::class)
+        ->assertSuccessful()
+        ->assertCountTableRecords(ActivityLog::count());
+});

--- a/tests/Filament/Admin/ListActivitiesTest.php
+++ b/tests/Filament/Admin/ListActivitiesTest.php
@@ -4,6 +4,7 @@ use App\Facades\Activity;
 use App\Filament\Admin\Resources\Activities\Pages\ListActivities;
 use App\Models\ActivityLog;
 use App\Models\Role;
+use Filament\Actions\Testing\TestAction;
 use Filament\Facades\Filament;
 use Spatie\Permission\Models\Permission;
 
@@ -63,4 +64,18 @@ it('user with view activityLog can see the viewer', function () {
     livewire(ListActivities::class)
         ->assertSuccessful()
         ->assertCountTableRecords(ActivityLog::count());
+});
+
+it('user with view activityLog can open the properties modal', function () {
+    $role = Role::factory()->create(['name' => 'Modal Auditor', 'guard_name' => 'web']);
+    $role->givePermissionTo(Permission::findOrCreate('view activityLog', 'web'));
+    [$user] = generateTestAccount([]);
+    $user = $user->syncRoles($role);
+
+    $log = Activity::event('auth:success')->log();
+
+    $this->actingAs($user);
+    livewire(ListActivities::class)
+        ->callAction(TestAction::make('view')->table($log))
+        ->assertHasNoActionErrors();
 });


### PR DESCRIPTION
Adds a read-only Activity resource to the admin panel (Advanced group) that lists every activity log across panels, with event/actor/subject/date-range filters and a properties modal. The query is deliberately unscoped and ignores `activity.hide_admin_activity`, since this is the audit view for admins.

Access is gated on a new `view activityLog` special permission (`seeIps` alone doesn't grant it); the permission shows up in the role form automatically via `Role::getPermissionList()` and root admin bypasses as usual.


<img width="1145" alt="admin activity viewer" src="https://github.com/user-attachments/assets/8edc1cb8-c819-4beb-8d83-d5dd893718c3" />
