### PR TITLE
Log panel settings changes with a redacted old-to-new diff

### DIFF
--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -15,6 +15,7 @@ use App\Traits\Filament\CanCustomizeTabs;
 use BackedEnum;
 use BladeUI\Icons\Exceptions\SvgNotFound;
 use BladeUI\Icons\Factory as IconFactory;
+use Dotenv\Dotenv;
 use Exception;
 use Filament\Actions\Action;
 use Filament\Actions\ActionGroup;
@@ -45,6 +46,7 @@ use Filament\Schemas\Schema;
 use Filament\Support\Enums\Width;
 use Illuminate\Http\Client\Factory;
 use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\App;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Notification as MailNotification;
 use Illuminate\Support\Str;
@@ -1009,22 +1011,21 @@ class Settings extends Page implements HasSchemas
 
     /**
      * Old-to-new pairs for every env key actually changing, secrets masked.
-     * Snapshotted through env() before the write, since the loaded environment
-     * still holds the previous values at that point.
+     * Snapshotted by parsing the environment file directly, because env()
+     * returns null for .env-only keys once the configuration is cached.
      *
      * @param  array<string, mixed>  $data
      * @return array<string, array{old: string|null, new: string|null}>
      */
     private function buildSettingsDiff(array $data): array
     {
+        $path = App::environmentFilePath();
+        $current = is_file($path) ? Dotenv::parse(file_get_contents($path)) : [];
+
         $changes = [];
 
         foreach ($data as $key => $value) {
-            $old = env($key);
-
-            if (is_bool($old)) {
-                $old = $old ? 'true' : 'false';
-            }
+            $old = $current[$key] ?? null;
 
             $old = is_null($old) ? null : (string) $old;
             $new = match (true) {

--- a/app/Filament/Admin/Pages/Settings.php
+++ b/app/Filament/Admin/Pages/Settings.php
@@ -6,6 +6,7 @@ use App\Enums\TablerIcon;
 use App\Extensions\Avatar\AvatarService;
 use App\Extensions\Captcha\CaptchaService;
 use App\Extensions\OAuth\OAuthService;
+use App\Facades\Activity;
 use App\Notifications\MailTested;
 use App\Traits\EnvironmentWriterTrait;
 use App\Traits\Filament\CanCustomizeHeaderActions;
@@ -979,7 +980,15 @@ class Settings extends Page implements HasSchemas
                 return $value;
             }, $data);
 
+            $changes = $this->buildSettingsDiff($data);
+
             $this->writeToEnvironment($data);
+
+            if ($changes !== []) {
+                Activity::event('settings:update')
+                    ->property('changes', $changes)
+                    ->log();
+            }
 
             Artisan::call('queue:restart');
 
@@ -996,6 +1005,47 @@ class Settings extends Page implements HasSchemas
                 ->danger()
                 ->send();
         }
+    }
+
+    /**
+     * Old-to-new pairs for every env key actually changing, secrets masked.
+     * Snapshotted through env() before the write, since the loaded environment
+     * still holds the previous values at that point.
+     *
+     * @param  array<string, mixed>  $data
+     * @return array<string, array{old: string|null, new: string|null}>
+     */
+    private function buildSettingsDiff(array $data): array
+    {
+        $changes = [];
+
+        foreach ($data as $key => $value) {
+            $old = env($key);
+
+            if (is_bool($old)) {
+                $old = $old ? 'true' : 'false';
+            }
+
+            $old = is_null($old) ? null : (string) $old;
+            $new = match (true) {
+                is_null($value) => null,
+                is_array($value) => implode(',', $value),
+                default => (string) $value,
+            };
+
+            if ($old === $new) {
+                continue;
+            }
+
+            if (Str::is(['*SECRET*', '*PASSWORD*', '*TOKEN*', '*_KEY'], $key)) {
+                $old = is_null($old) || $old === '' ? $old : '********';
+                $new = is_null($new) || $new === '' ? $new : '********';
+            }
+
+            $changes[$key] = ['old' => $old, 'new' => $new];
+        }
+
+        return $changes;
     }
 
     /** @return array<Action|ActionGroup> */

--- a/lang/en/activity.php
+++ b/lang/en/activity.php
@@ -38,6 +38,9 @@ return [
             'delete' => 'Disabled two-factor auth',
         ],
     ],
+    'settings' => [
+        'update' => 'Updated <b>:count</b> panel setting|Updated <b>:count</b> panel settings',
+    ],
     'server' => [
         'console' => [
             'command' => 'Executed "<b>:command</b>" on the server',

--- a/tests/Filament/Admin/SettingsTest.php
+++ b/tests/Filament/Admin/SettingsTest.php
@@ -1,8 +1,10 @@
 <?php
 
+use App\Events\ActivityLogged;
 use App\Filament\Admin\Pages\Settings;
 use App\Models\Role;
 use Filament\Facades\Filament;
+use Illuminate\Support\Facades\Event;
 
 use function Pest\Livewire\livewire;
 
@@ -24,6 +26,46 @@ it('is forbidden for a user without permission', function () {
 
     $this->actingAs($user);
     livewire(Settings::class)->assertForbidden();
+});
+
+it('logs a settings:update event with a redacted diff', function () {
+    $path = sys_get_temp_dir().'/pelican-settings-test-'.getmypid();
+    @mkdir($path);
+    file_put_contents("$path/.env", '');
+    app()->useEnvironmentPath($path);
+
+    try {
+        livewire(Settings::class)
+            ->fillForm([
+                'APP_NAME' => 'Audited Panel',
+                'FILAMENT_AVATAR_PROVIDER' => 'gravatar',
+                // smtp keeps the MAIL_PASSWORD field visible so it lands in the diff
+                'MAIL_MAILER' => 'smtp',
+                'MAIL_HOST' => 'localhost',
+                'MAIL_PORT' => 2525,
+                'MAIL_SCHEME' => 'smtp',
+                'MAIL_PASSWORD' => 'supersecretpw',
+                'GUZZLE_CONNECT_TIMEOUT' => 5,
+            ])
+            ->call('save')
+            ->assertHasNoErrors();
+
+        $this->assertActivityLogged('settings:update');
+        $this->assertActivityActor('settings:update', $this->admin);
+        Event::assertDispatched(ActivityLogged::class, function (ActivityLogged $e) {
+            if (!$e->is('settings:update')) {
+                return false;
+            }
+            $changes = $e->model->properties['changes'];
+
+            return $changes['APP_NAME']['new'] === 'Audited Panel'
+                && $changes['MAIL_PASSWORD']['new'] === '********'
+                && !str_contains(json_encode($e->model->properties), 'supersecretpw');
+        });
+    } finally {
+        @unlink("$path/.env");
+        @rmdir($path);
+    }
 });
 
 it('persists saved settings to the environment file', function () {


### PR DESCRIPTION
`Settings::save()` now snapshots the loaded environment before writing `.env` and logs a `settings:update` event carrying only the keys that actually changed, as old-to-new pairs. Keys matching `*SECRET*`/`*PASSWORD*`/`*TOKEN*`/`*_KEY` are masked, and a save that changes nothing logs nothing. The CLI `p:environment:*` commands stay unaudited for now.

This settings-to-database work can carry the logging over when it rewrites `save()`.
<img width="770" alt="settings update event with redacted diff" src="https://github.com/user-attachments/assets/2ea98607-85ee-478c-9018-3c1d661d1fb7" />
