### PR TITLE
Refresh contributor docs, add PR template, code of conduct, and code standards

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,7 @@
+Resolves #
+
+## Checklist
+
+- [ ] This pull request does one thing (unrelated changes are split into separate pull requests)
+- [ ] New translation strings are added to English only (other languages come from [Crowdin](https://crowdin.com/project/pelican-dev))
+- [ ] UI changes include before/after screenshots

--- a/code-standards.md
+++ b/code-standards.md
@@ -1,0 +1,32 @@
+# Code Standards
+
+Code style, static analysis, and tests are enforced by CI on every pull request; run them locally before pushing. The conventions at the bottom are checked in review.
+
+## Code Style
+
+We use [Pint](https://laravel.com/docs/pint) with the `laravel` preset plus a few overrides; see [pint.json](./pint.json).
+
+Run it with `composer pint`.
+
+## Static Analysis
+
+[Larastan](https://github.com/larastan/larastan) (PHPStan) must pass without errors. The configuration lives in [phpstan.neon](./phpstan.neon) and includes a custom rule (`App\PHPStan\ForbiddenGlobalFunctionsRule`) that forbids the global `app()` and `resolve()` helpers; use dependency injection instead.
+
+Run it with `composer phpstan`.
+
+## Tests
+
+Tests are written with [Pest](https://pestphp.com) and live in `tests/Unit`, `tests/Integration`, and `tests/Filament`. New features and bug fixes should come with tests. CI runs the suites against both SQLite and MySQL.
+
+Run the whole suite with `vendor/bin/pest` (add `--parallel` to speed it up).
+
+## API Contract
+
+The HTTP API is frozen: from 1.0 onward, responses and accepted request inputs only change in backwards-compatible ways. Read [api-versioning.md](./api-versioning.md) before changing anything the API returns or accepts.
+
+## Conventions
+
+* Use backed enums in `app/Enums` instead of class constants.
+* Panel UI is built with Filament: the three panels live in `app/Filament/Admin`, `app/Filament/Server`, and `app/Filament/App`, with shared components in `app/Filament/Components`.
+* Translation strings go in `lang/en` only; other languages are managed through [Crowdin](https://crowdin.com/project/pelican-dev).
+* Database changes are made through new migrations; do not edit migrations that have already shipped.

--- a/code_of_conduct.md
+++ b/code_of_conduct.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+* Demonstrating empathy and kindness toward other people
+* Being respectful of differing opinions, viewpoints, and experiences
+* Giving and gracefully accepting constructive feedback
+* Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+* Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+* The use of sexualized language or imagery, and sexual attention or advances
+  of any kind
+* Trolling, insulting or derogatory comments, and personal or political attacks
+* Public or private harassment
+* Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+* Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official e-mail address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+<team@pelican.dev>.
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][Mozilla CoC].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][FAQ]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[Mozilla CoC]: https://github.com/mozilla/diversity
+[FAQ]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/contributing.md
+++ b/contributing.md
@@ -2,6 +2,8 @@
 
 Welcome to the Pelican project! We are excited to have you contribute to our open-source project. This guide will help you get started with setting up your development environment, understanding our coding standards, and making your first or next contribution.
 
+Please also read our [code of conduct](./code_of_conduct.md).
+
 ## Getting started
 
 To start contributing to Pelican Panel, you need to have a basic understanding of the following:
@@ -10,25 +12,28 @@ To start contributing to Pelican Panel, you need to have a basic understanding o
 * [Livewire](https://laravel-livewire.com) & [Filament](https://filamentphp.com)
 * [Git](https://git-scm.com) & [GitHub](https://github.com)
 
+User guides live in the [Pelican documentation](https://pelican.dev/docs), not in this repository.
+
 ## Dev Environment Setup
 
-1. Fork the Repository
-2. Clone your Fork
-3. Install Dependencies (PHP modules & composer, and run `composer install`)
-4. Configure your Environment (via `php artisan p:environment:setup`)
-5. Set up your Database (via `php artisan p:environment:database`) and run Migrations (via `php artisan migrate --seed --force`)
-6. Create your first Admin User (via `php artisan p:user:make`)
-7. Start your Webserver (e.g. Nginx or Apache)
+The quickest way to get PHP and a webserver running locally is [Laravel Herd](https://herd.laravel.com) ([Windows](https://herd.laravel.com/windows) & [macOS](https://herd.laravel.com)). The (paid) Pro version adds easy MySQL and Redis hosting, but the free version with SQLite is fine for most cases. Any other PHP + webserver setup (e.g. Nginx or Apache) works too.
 
-As IDE we recommend [Visual Studio](https://visualstudio.microsoft.com)/ [Visual Studio Code](https://code.visualstudio.com) (free) or [PhpStorm](https://www.jetbrains.com/phpstorm) (paid).
+1. Fork the repository and clone your fork
+2. Install PHP dependencies: `composer install`
+3. Build the frontend assets: `npm install` and `npm run build` (use `npm run dev` while developing)
+4. Configure your environment: `php artisan p:environment:setup`
+5. Set up your database: `php artisan p:environment:database`, then run `php artisan migrate --seed --force`
+6. Create your first admin user: `php artisan p:user:make`
+7. Open the panel in your browser (via Herd's site URL or your webserver)
 
-To easily install PHP and the Webserver we recommend Laravel Herd. ([Windows](https://herd.laravel.com/windows) & [macOS](https://herd.laravel.com))  
-The (paid) Pro version of Laravel Herd also offers easy MySQL and Redis hosting, but the free version is fine for most cases.
+As IDE we recommend [Visual Studio Code](https://code.visualstudio.com) (free) or [PhpStorm](https://www.jetbrains.com/phpstorm) (paid).
 
 ## Coding Standards
 
-We use PHPStan/ [Larastan](https://github.com/larastan/larastan) and PHP-CS-Fixer/ [Pint](https://laravel.com/docs/12.x/pint) to enforce certain code styles and standards.  
-You can run PHPStan via `\vendor\bin\phpstan analyse` and Pint via `\vendor\bin\pint`.
+We use PHPStan/ [Larastan](https://github.com/larastan/larastan) and [Pint](https://laravel.com/docs/pint) to enforce certain code styles and standards.  
+You can run PHPStan via `composer phpstan` and Pint via `composer pint`.
+
+See [code-standards.md](./code-standards.md) for the full rundown of tooling, tests, and codebase conventions.
 
 ## Making Contributions
 
@@ -36,6 +41,18 @@ From your forked repository, make your own changes on your own branch. (do not m
 When you are ready, you can submit a pull request to the Pelican repository. If you still work on your pull request or need help with something make sure to mark it as Draft.
 
 Also, please make sure that your pull requests are as targeted and simple as possible and don't do a hundred things at a time. If you want to add/ change/ fix 5 different things you should make 5 different pull requests.
+
+### Before opening a pull request
+
+CI runs all of the following on every pull request, so save yourself a review round trip and run them locally first:
+
+* `composer pint` (code style)
+* `composer phpstan` (static analysis)
+* `vendor/bin/pest` (tests; CI runs them against both SQLite and MySQL)
+
+### Contributor License Agreement
+
+All contributors must sign our [Contributor License Agreement](./contributor_license_agreement.md). The CLA Assistant bot will ask you to sign it on your first pull request; posting the comment it asks for completes the signature.
 
 ### Translations
 

--- a/security.md
+++ b/security.md
@@ -16,3 +16,5 @@ Include steps to reproduce, affected versions, impact, and a proof of concept if
 
 You can expect a response within 72 hours.  
 Please do not disclose vulnerabilities publicly until we have released a fix. We will acknowledge receipt and can credit researchers upon request.
+
+All interactions around vulnerability reports are covered by our [code of conduct](./code_of_conduct.md).


### PR DESCRIPTION
Fixes the broken `\vendor\bin` paths in contributing.md (now `composer pint` / `composer phpstan`), refreshes the dev environment setup (Herd-first with SQLite, frontend asset build, verified artisan commands), documents the pre-PR checks and the CLA Assistant signing flow, and links the user docs.

Adds `.github/PULL_REQUEST_TEMPLATE.md`, a Contributor Covenant 2.1 `code_of_conduct.md` (contact: team@pelican.dev, cross-linked from contributing.md and security.md), and `code-standards.md` covering Pint, Larastan (including the forbidden `app()`/`resolve()` rule), Pest suites, the API contract freeze, and codebase conventions.

The supported-versions wording in security.md is left to #2567; labels and good-first-issue seeding are handled outside this PR. The CLA is already enforced by `cla.yaml`, so no workflow changes.
